### PR TITLE
fix: 兼容终端 Enter 键发送 \r 而非 key.return 的情况

### DIFF
--- a/src/platforms/console/App.tsx
+++ b/src/platforms/console/App.tsx
@@ -388,7 +388,7 @@ export function App({ onReady, onSubmit, onNewSession, onLoadSession, onListSess
         setSelectedIndex((prev: number) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
         setSelectedIndex((prev: number) => Math.min(sessionList.length - 1, prev + 1));
-      } else if (key.return) {
+      } else if (key.return || input === '\r') {
         const selected =sessionList[selectedIndex];
         if (selected) {
           setMessages([]);
@@ -413,7 +413,7 @@ export function App({ onReady, onSubmit, onNewSession, onLoadSession, onListSess
         setSelectedIndex((prev: number) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
         setSelectedIndex((prev: number) => Math.min(modelList.length - 1, prev + 1));
-      } else if (key.return) {
+      } else if (key.return || input === '\r') {
         const selected = modelList[selectedIndex];
         if (selected) {
           const result = onSwitchModel(selected.modelName);

--- a/src/platforms/console/components/InputBar.tsx
+++ b/src/platforms/console/components/InputBar.tsx
@@ -143,16 +143,16 @@ export function InputBar({ disabled, onSubmit }: InputBarProps) {
     // ---- Ctrl+C ----
     if (key.ctrl && input === 'c') return;
 
-    // ---- Line Feed (\n): 换行（常见于 Ctrl+J；部分终端会把它当作独立键发送） ----
-    // Ink 在很多终端里无法区分 Shift+Enter，但通常可以收到 Ctrl+J（\n）。
-    if (input === '\n') {
-      insertNewLine();
+    // ---- Enter / Return：提交 ----
+    // 某些终端会将 Enter 发送为 \r 而非触发 key.return，需要统一处理。
+    if (key.return || input === '\r') {
+      doSubmit();
       return;
     }
 
-    // ---- Enter：提交 ----
-    if (key.return) {
-      doSubmit();
+    // ---- Line Feed (\n): 换行（Ctrl+J） ----
+    if (input === '\n') {
+      insertNewLine();
       return;
     }
 

--- a/src/platforms/console/components/SettingsView.tsx
+++ b/src/platforms/console/components/SettingsView.tsx
@@ -808,6 +808,10 @@ export function SettingsView({ initialSection = 'general', onBack, onLoad, onSav
         setEditorValue('');
         setStatus('已取消编辑', 'warning');
       }
+      // 兼容某些终端 Enter 发送 \r 而非 key.return
+      if (input === '\r') {
+        submitEditor();
+      }
       return;
     }
 
@@ -899,7 +903,7 @@ export function SettingsView({ initialSection = 'general', onBack, onLoad, onSav
       return;
     }
 
-    if (key.return && selectedRow?.target) {
+    if ((key.return || input === '\r') && selectedRow?.target) {
       if (selectedRow.target.kind === 'action') {
         if (selectedRow.target.action === 'addMcp') {
           handleAddMcpServer();


### PR DESCRIPTION
## Summary

- 修复某些 SSH 终端中 Enter 键发送 `\r`（CR）而非 Ink 识别的 `key.return`，导致 TUI 中所有需要 Enter 确认的操作完全失效的问题
- 在所有 `key.return` 判断处增加 `input === '\r'` 兼容检查

## 涉及文件

- **InputBar.tsx**: 主输入框提交（发消息、执行命令）
- **App.tsx**: 会话列表和模型列表的 Enter 确认
- **SettingsView.tsx**: 设置项编辑和选择的 Enter 确认

## 测试

在 SSH 终端（Enter 发送 `\r`）中验证通过：发送消息、`/settings`、`/load`、`/model` 等均恢复正常。