### PR TITLE
feat(mcp): 工具图片旁路发送 + Telegram sendPhoto

### DIFF
--- a/src/core/backend.ts
+++ b/src/core/backend.ts
@@ -32,11 +32,13 @@ import { COMPUTER_USE_FUNCTION_NAMES } from '../computer-use/tools';
 import { sanitizeHistory } from './history-sanitizer';
 import { estimateTokenCount } from 'tokenx';
 import {
-  Content, Part, LLMRequest, UsageMetadata, ToolInvocation,
   extractText, isFunctionCallPart, isFunctionResponsePart, isInlineDataPart, isTextPart,
 } from '../types';
+// 上游 main 新增的 summary 相关导入
 import type { SummaryConfig } from '../config/types';
 import { summarizeHistory } from './summarizer';
+// feat 分支新增的 ToolAttachment 类型（MCP 附件旁路功能需要）
+import type { Content, Part, LLMRequest, UsageMetadata, ToolInvocation, ToolAttachment } from '../types';
 import { resizeImage, formatDimensionNote } from '../media/image-resize.js';
 import { extractDocument, isSupportedDocumentMime } from '../media/document-extract.js';
 import { convertToPDF } from '../media/office-to-pdf.js';
@@ -210,6 +212,13 @@ export interface BackendEvents {
   'assistant:content': (sessionId: string, content: Content) => void;
   /** 自动上下文压缩完成（阈值触发） */
   'auto-compact': (sessionId: string, summaryText: string) => void;
+  /**
+   * 工具执行产生的附件（例如 MCP 生图结果）。
+   *
+   * 这里是平台层的旁路通道：附件不进入 LLM 上下文，
+   * 由具体平台自己决定如何发送给用户。
+   */
+  'attachments': (sessionId: string, attachments: ToolAttachment[]) => void;
 }
 
 // ============ Backend 类 ============
@@ -978,7 +987,16 @@ export class Backend extends EventEmitter {
     const result = await loop.run(history, callLLM, {
       extraParts,
       onMessageAppend: (content) => this.storage.addMessage(sessionId, content),
+      // 上游 main 新增：模型输出完成后通知平台层
       onModelContent: (content) => { this.emit('assistant:content', sessionId, content); },
+      // feat 分支新增：MCP 附件单独旁路给平台层
+      // 文本继续走原有 tool loop / history 流程，
+      // 图片等二进制内容直接由 Telegram / Discord / Lark 等平台发送，
+      // 这样不会把 base64 图片带进历史，也不会撑爆上下文。
+      onAttachments: (attachments) => {
+        logger.info(`[handleMessage] onAttachments 回调触发: sessionId=${sessionId}, count=${attachments.length}, types=${attachments.map(a => `${a.type}(${a.data.length}B)`).join(',')}`);
+        this.emit('attachments', sessionId, attachments);
+      },
       signal,
       onRetry: (attempt, maxRetries, error) => {
         this.emit('retry', sessionId, attempt, maxRetries, error);

--- a/src/core/tool-loop.ts
+++ b/src/core/tool-loop.ts
@@ -30,9 +30,9 @@ import type {
 } from '../plugins/types';
 import { createLogger } from '../logger';
 import {
-  Content, Part, LLMRequest, extractText, isFunctionCallPart,
-  FunctionCallPart, FunctionResponsePart,
+  extractText, isFunctionCallPart,
 } from '../types';
+import type { Content, Part, LLMRequest, FunctionCallPart, FunctionResponsePart, ToolAttachment } from '../types';
 import { cleanupTrailingHistory } from './history-sanitizer';
 
 const logger = createLogger('ToolLoop');
@@ -79,6 +79,13 @@ export interface ToolLoopRunOptions {
   onMessageAppend?: (content: Content) => Promise<void>;
   /** 一轮模型输出完成后的回调（在插件 afterLLMCall 之后、写入历史之前） */
   onModelContent?: (content: Content, round: number) => Promise<void> | void;
+  /**
+   * 工具执行时产生的附件（例如 MCP 返回的图片）。
+   *
+   * 这些附件不进入 LLM 上下文，由平台层直接发送给用户，
+   * 避免把 base64 当作文本塞进历史。
+   */
+  onAttachments?: (attachments: ToolAttachment[]) => void;
   /** 固定使用的模型名称；不填时由调用方自行决定默认模型 */
   modelName?: string;
   /** 中止信号：触发后安全退出循环并清理历史 */
@@ -186,7 +193,7 @@ export class ToolLoop {
       }
 
       // 执行工具（通过 scheduler 分批调度）
-      const responseParts = await this.executeTools(functionCalls, signal);
+      const responseParts = await this.executeTools(functionCalls, signal, options?.onAttachments);
 
       // 工具执行后再次检查 abort
       if (signal?.aborted) {
@@ -283,7 +290,11 @@ export class ToolLoop {
     return '';
   }
 
-  private async executeTools(calls: FunctionCallPart[], signal?: AbortSignal): Promise<FunctionResponsePart[]> {
+  private async executeTools(
+    calls: FunctionCallPart[],
+    signal?: AbortSignal,
+    onAttachments?: (attachments: ToolAttachment[]) => void,
+  ): Promise<FunctionResponsePart[]> {
     const plan = buildExecutionPlan(calls, this.tools);
 
     if (this.toolState) {
@@ -305,6 +316,7 @@ export class ToolLoop {
         signal,
         this.config.beforeToolExec,
         this.config.afterToolExec,
+        onAttachments,
       );
     }
 
@@ -319,6 +331,7 @@ export class ToolLoop {
       signal,
       this.config.beforeToolExec,
       this.config.afterToolExec,
+      onAttachments,
     );
   }
 }

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -11,8 +11,9 @@
  */
 
 import { MCPServerConfig } from '../config/types';
-import { MCPClientStatus } from './types';
 import { createLogger } from '../logger';
+import type { ToolAttachment } from '../types';
+import { MCPClientStatus } from './types';
 
 const logger = createLogger('MCPClient');
 
@@ -32,7 +33,19 @@ interface SDKTool {
 interface SDKContentBlock {
   type: string;
   text?: string;
+  data?: string;
+  mimeType?: string;
   [key: string]: unknown;
+}
+
+/** MCP 工具调用的结构化结果。
+ *
+ * text 会继续回传给 LLM 作为工具执行结果；attachments 则由平台层直接发送给用户，
+ * 这样可以避免把图片 base64 当作文本塞进上下文。
+ */
+export interface MCPToolResult {
+  text: string;
+  attachments: ToolAttachment[];
 }
 
 export class MCPClient {
@@ -133,7 +146,7 @@ export class MCPClient {
       case 'streamable-http': {
         // @ts-ignore — ESM subpath import
         const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
-     const opts: any = {};
+        const opts: any = {};
         if (this.config.headers) {
           opts.requestInit = { headers: this.config.headers };
         }
@@ -143,7 +156,7 @@ export class MCPClient {
   }
 
   /** 调用工具 */
-  async callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+  async callTool(name: string, args: Record<string, unknown>): Promise<MCPToolResult> {
     if (!this.client || this._status !== 'connected') {
       throw new Error(`MCP 服务器 "${this.serverName}" 未连接`);
     }
@@ -155,7 +168,68 @@ export class MCPClient {
       throw new Error(text || `MCP 工具 "${name}" 执行失败`);
     }
 
-    return this.extractText(result.content);
+    return this.parseToolResult(result.content, name);
+  }
+
+  /**
+   * 解析 MCP 工具结果。
+   *
+   * 目标很明确：
+   * - 纯文本回给 LLM，保持工具循环可读
+   * - 图片等二进制内容转成附件，交给平台层直接发送
+   * - 不把 base64 作为普通文本塞进上下文，避免上下文爆炸
+   */
+  private parseToolResult(content: SDKContentBlock[], toolName: string): MCPToolResult {
+    const texts: string[] = [];
+    const attachments: ToolAttachment[] = [];
+
+    // 调试日志：查看 MCP 工具返回的原始 content 块类型和结构，
+    // 用于排查图片附件是否被正确识别（type/data/mimeType 三字段缺一则跳过）。
+    logger.info(`[parseToolResult] 工具 "${toolName}" 返回 ${Array.isArray(content) ? content.length : 0} 个 content block，`
+      + `类型: ${Array.isArray(content) ? content.map(b => `${b.type}(keys=${Object.keys(b).join('+')})`).join(', ') : typeof content}`);
+
+    if (!Array.isArray(content)) {
+      return { text: String(content), attachments: [] };
+    }
+
+    for (const block of content) {
+      if (block.type === 'text' && typeof block.text === 'string' && block.text.trim()) {
+        texts.push(block.text);
+        continue;
+      }
+
+      // MCP ImageContent: { type: 'image', data: base64string, mimeType: 'image/png' }
+      if (block.type === 'image' && typeof block.data === 'string' && typeof block.mimeType === 'string') {
+        logger.info(`[parseToolResult] 发现图片 block: mimeType=${block.mimeType}, data 长度=${block.data.length}`);
+        attachments.push({
+          type: 'image',
+          mimeType: block.mimeType,
+          // SDK 的 data 字段是 base64 编码的字符串，
+          // 转成 Buffer 方便 Telegram / Discord 等平台直接发送二进制内容。
+          data: Buffer.from(block.data, 'base64'),
+          toolName,
+        });
+      }
+    }
+
+    // 调试日志：汇总解析结果，帮助定位图片附件是否从 MCP response 中正确提取。
+    // 如果 attachments=0 但工具确实生成了图片，说明 SDK 返回的 block 格式不符合预期。
+    logger.info(`[parseToolResult] 解析完成: texts=${texts.length}, attachments=${attachments.length}`);
+    if (attachments.length === 0 && Array.isArray(content) && content.length > 0) {
+      logger.info(`[parseToolResult] 未发现图片附件。各 block 的 keys: ${content.map(b => JSON.stringify(Object.keys(b))).join(' | ')}`);
+    }
+
+    // 如果工具结果里带了图片，但文本里没有明确说明，补一条轻量摘要给 LLM。
+    // 目的：让模型知道“图片已经生成并发送给用户”，而不是只看到一段历史 ID。
+    const hasAttachmentHint = texts.some((text) => /图片|image/i.test(text));
+    if (attachments.length > 0 && !hasAttachmentHint) {
+      texts.push(`已生成 ${attachments.length} 张图片，并直接发送给用户。`);
+    }
+
+    return {
+      text: texts.join('\n').trim(),
+      attachments,
+    };
   }
 
   /** 从内容块数组中提取文本 */
@@ -181,7 +255,7 @@ export class MCPClient {
       this.client = null;
       this.transport = null;
       this._tools = [];
-   this._status = 'disconnected';
+      this._status = 'disconnected';
       this._error = undefined;
     }
   }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -5,6 +5,7 @@
 export { MCPClient } from './client';
 export { MCPManager } from './manager';
 export type { MCPClientStatus, MCPServerInfo } from './types';
+export type { MCPToolResult } from './client';
 
 import { MCPConfig } from '../config/types';
 import { MCPManager } from './manager';

--- a/src/platforms/telegram/client.ts
+++ b/src/platforms/telegram/client.ts
@@ -8,7 +8,7 @@
  * 4. 为文件下载、回调按钮等能力预留稳定边界。
  */
 
-import { Bot, Context } from 'grammy';
+import { Bot, Context, InputFile } from 'grammy';
 import { splitText } from '../base';
 import { createLogger } from '../../logger';
 import { TELEGRAM_BOT_COMMANDS } from './commands';
@@ -120,6 +120,25 @@ export class TelegramClient {
 
   async deleteMessage(target: TelegramSessionTarget, messageId: number): Promise<void> {
     await this.bot.api.deleteMessage(target.chatId, messageId);
+  }
+
+  /**
+   * 直接向 Telegram 发送图片。
+   *
+   * 这里使用 InputFile 包装 Buffer，避免先落盘再读取，减少一次不必要的 I/O。
+   * 这条链路是附件旁路的终点：图片不进 LLM 上下文，直接给用户看。
+   */
+  async sendPhoto(target: TelegramSessionTarget, photo: Buffer, caption?: string): Promise<number> {
+    const extra: Record<string, unknown> = {};
+    if (target.threadId != null) {
+      extra.message_thread_id = target.threadId;
+    }
+    if (caption) {
+      extra.caption = caption;
+    }
+    const inputFile = new InputFile(photo);
+    const msg = await this.bot.api.sendPhoto(target.chatId, inputFile, extra);
+    return msg.message_id;
   }
 
   async getFile(fileId: string) {

--- a/src/platforms/telegram/index.ts
+++ b/src/platforms/telegram/index.ts
@@ -23,6 +23,7 @@ import {
   TelegramPendingMessage,
   TelegramSessionTarget,
 } from './types';
+import type { ToolAttachment } from '../../types';
 
 const logger = createLogger('Telegram');
 
@@ -194,6 +195,31 @@ export class TelegramPlatform extends PlatformAdapter {
 
       if (!displayText) return;
       this.editStreamMessage(cs, displayText);
+    });
+
+    // ---- 工具附件（图片等） ----
+    this.backend.on('attachments', (sid: string, attachments: ToolAttachment[]) => {
+      const cs = this.findChatStateBySid(sid);
+      // 调试日志：确认 attachments 事件是否到达 Telegram 平台层
+      logger.info(`[attachments] 收到附件事件: sid=${sid}, count=${attachments.length}, cs=${!!cs}, stopped=${cs?.stopped}`);
+      if (!cs || cs.stopped || attachments.length === 0) {
+        logger.info(`[attachments] 跳过: cs=${!!cs}, stopped=${cs?.stopped}, count=${attachments.length}`);
+        return;
+      }
+
+      // 附件是平台级能力，不进入 LLM 上下文。
+      // 这里直接把图片发给用户，文本摘要仍会通过后续 response 事件送出。
+      void (async () => {
+        for (const att of attachments) {
+          if (att.type !== 'image') continue;
+          try {
+            logger.info(`[attachments] 正在发送图片到 Telegram: chatId=${cs.target.chatId}, dataSize=${att.data.length}`);
+            await this.client.sendPhoto(cs.target, att.data, att.caption);
+          } catch (err) {
+            logger.error('发送图片失败:', err);
+          }
+        }
+      })();
     });
 
     // ---- 流式输出 ----

--- a/src/tools/scheduler.ts
+++ b/src/tools/scheduler.ts
@@ -18,6 +18,7 @@ import { ToolRegistry } from './registry';
 import { ToolStateManager } from './state';
 import { FunctionCallPart, FunctionResponsePart, InlineDataPart } from '../types';
 import { createLogger } from '../logger';
+import type { ToolAttachment } from '../types';
 import { ToolPolicyConfig, ToolsConfig } from '../config';
 import type { BeforeToolExecInterceptor, AfterToolExecInterceptor } from '../plugins/types';
 
@@ -216,6 +217,7 @@ async function executeSingle(
   signal?: AbortSignal,
   beforeToolExec?: BeforeToolExecInterceptor,
   afterToolExec?: AfterToolExecInterceptor,
+  onAttachments?: (attachments: ToolAttachment[]) => void,
 ): Promise<FunctionResponsePart> {
   const toolName = call.functionCall.name;
 
@@ -311,6 +313,10 @@ async function executeSingle(
     let result = await registry.execute(toolName, effectiveArgs);
     const durationMs = Date.now() - execStart;
 
+    // 保存原始返回值，用于 MCP 附件识别兜底（afterToolExec 可能改变 result 的结构）
+    const rawResult = result;
+
+    // 插件钩子：工具执行后拦截器（上游 main 新增）
     if (afterToolExec) {
       try {
         const interception = await afterToolExec(toolName, effectiveArgs, result, durationMs);
@@ -323,17 +329,40 @@ async function executeSingle(
       }
     }
 
-    // 工具可通过约定字段 __response / __parts 返回带多模态内联数据的结果。
-    // 适用于需要在工具结果中附带截图、音频等二进制数据的场景。
-    //   __response → functionResponse.response（扁平，不包在 { result } 里）
-    //   __parts    → functionResponse.parts（InlineDataPart 数组）
-    const isRichResult = result != null && typeof result === 'object'
-      && !Array.isArray(result) && '__response' in (result as Record<string, unknown>);
+    // MCP 结果识别：优先检查 afterToolExec 后的 result，回退到原始 rawResult。
+    // MCP 工具返回 { text, attachments }，把 text 留给 LLM，附件旁路给平台层。
+    const isMCPEnvelope = (v: unknown): v is { text: string; attachments: ToolAttachment[] } =>
+      v != null && typeof v === 'object' && !Array.isArray(v)
+      && typeof (v as any).text === 'string'
+      && Array.isArray((v as any).attachments);
+    const isMCPResult = isMCPEnvelope(result) || isMCPEnvelope(rawResult);
+    const mcpSource = isMCPEnvelope(result) ? result : (isMCPEnvelope(rawResult) ? rawResult : undefined);
+
+    // 现有约定：普通工具也可以通过 __response / __parts 返回富结果。
+    // 这是旧链路，保留不动，避免影响已有的截图/音频工具。
+    const isRichResult = !isMCPResult
+      && result != null
+      && typeof result === 'object'
+      && !Array.isArray(result)
+      && '__response' in (result as Record<string, unknown>);
 
     let response: Record<string, unknown>;
     let responseParts: InlineDataPart[] | undefined;
+    let stateResult: unknown = result;
 
-    if (isRichResult) {
+    if (isMCPResult) {
+      // mcpSource 已在上面通过 isMCPEnvelope 确定，此处断言安全
+      const mcp = mcpSource!;
+      response = { result: mcp.text };
+      logger.info(`[executeSingle] MCP 结果识别: tool=${toolName}, text长度=${mcp.text.length}, attachments=${mcp.attachments.length}`);
+      stateResult = mcp.text;
+
+      // 附件不进入 functionResponse.parts，否则会被历史/上下文继续携带。
+      // 这里通过回调旁路给平台层，让 Telegram / Discord / Lark 自己发图。
+      if (mcp.attachments.length > 0) {
+        onAttachments?.(mcp.attachments);
+      }
+    } else if (isRichResult) {
       const rich = result as Record<string, unknown>;
       response = (rich.__response as Record<string, unknown>) ?? {};
       responseParts = Array.isArray(rich.__parts) ? rich.__parts as InlineDataPart[] : undefined;
@@ -342,8 +371,9 @@ async function executeSingle(
     }
 
     if (toolState && invocationId) {
-      // 存储原始工具输出（非 API response 包裹），供 TUI 渲染器直接使用
-      toolState.transition(invocationId, 'success', { result });
+      // 存储尽量轻量的结果。MCP 图片附件已经通过 onAttachments 旁路发送，
+      // 这里不保留 Buffer，避免状态对象被大块二进制拖重。
+      toolState.transition(invocationId, 'success', { result: stateResult });
     }
     return {
       functionResponse: {
@@ -393,6 +423,7 @@ export async function executePlan(
   signal?: AbortSignal,
   beforeToolExec?: BeforeToolExecInterceptor,
   afterToolExec?: AfterToolExecInterceptor,
+  onAttachments?: (attachments: ToolAttachment[]) => void,
 ): Promise<FunctionResponsePart[]> {
   const responseParts: FunctionResponsePart[] = new Array(calls.length);
 
@@ -423,7 +454,7 @@ export async function executePlan(
 
       const results = await Promise.all(
         batch.indices.map(i =>
-          executeSingle(calls[i], registry, toolState, invocationIds?.[i], toolsConfig, signal, beforeToolExec, afterToolExec)
+          executeSingle(calls[i], registry, toolState, invocationIds?.[i], toolsConfig, signal, beforeToolExec, afterToolExec, onAttachments)
         ),
       );
       for (let j = 0; j < batch.indices.length; j++) {
@@ -431,7 +462,7 @@ export async function executePlan(
       }
     } else {
       for (const i of batch.indices) {
-        responseParts[i] = await executeSingle(calls[i], registry, toolState, invocationIds?.[i], toolsConfig, signal, beforeToolExec, afterToolExec);
+        responseParts[i] = await executeSingle(calls[i], registry, toolState, invocationIds?.[i], toolsConfig, signal, beforeToolExec, afterToolExec, onAttachments);
       }
     }
   }

--- a/src/types/attachment.ts
+++ b/src/types/attachment.ts
@@ -1,0 +1,21 @@
+/**
+ * 工具执行附件类型。
+ *
+ * 目的：把 MCP 工具等返回的图片/音频/文件从 LLM 上下文里旁路出去，
+ * 让平台层按各自能力直接发送给用户，避免把 base64 当文本塞进历史。
+ */
+
+export interface ToolAttachment {
+  /** 附件类型。当前先支持图片，后续可扩展音频、文件。 */
+  type: 'image' | 'audio' | 'file';
+  /** MIME 类型，如 image/png。 */
+  mimeType: string;
+  /** 附件二进制内容。 */
+  data: Buffer;
+  /** 可选文件名。 */
+  fileName?: string;
+  /** 可选来源工具名。 */
+  toolName?: string;
+  /** 可选说明文字，供平台展示为 caption。 */
+  caption?: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './message';
 export * from './tool';
 export * from './llm';
 export * from './platform';
+export * from './attachment';


### PR DESCRIPTION
## 改动

- MCP 工具返回的 `ImageContent` 不再被丢弃，通过新增的 `attachments` 事件旁路发送给用户
- 图片不进入 LLM 上下文，不写入历史存储
- LLM 只收到轻量文本摘要（如「已生成 1 张图片，并直接发送给用户」）
- Telegram 作为首个平台实现 `sendPhoto`
- 附件类型预留了 `audio` / `file` 扩展位，后续可直接复用同一条链路

### 新增文件

- `src/types/attachment.ts` — `ToolAttachment` 接口（`type: 'image' | 'audio' | 'file'`）

### 变更文件

| 文件 | 改动 |
|------|------|
| `src/mcp/client.ts` | `callTool()` 返回 `MCPToolResult`，新增 `parseToolResult()` 拆分 text / image |
| `src/mcp/index.ts` | 导出 `MCPToolResult` 类型 |
| `src/tools/scheduler.ts` | `executeSingle` / `executePlan` 增加 `onAttachments` 回调，识别 MCPToolResult 并旁路附件 |
| `src/core/tool-loop.ts` | `ToolLoopRunOptions` 增加 `onAttachments`，透传到 scheduler |
| `src/core/backend.ts` | `BackendEvents` 新增 `'attachments'` 事件，`handleMessage` 注入回调 |
| `src/platforms/telegram/client.ts` | 新增 `sendPhoto()`，使用 grammY `InputFile` 包装 Buffer |
| `src/platforms/telegram/index.ts` | 监听 `attachments` 事件，调用 `sendPhoto` 发图 |
| `src/types/index.ts` | 导出 `attachment` 模块 |

## 原因

MCP 生态的经典问题：MCP server 返回 `ImageContent`（base64），客户端如果当文本处理会撑爆上下文。
此前 Iris 的 MCP client 只提取 `type=text`，`type=image` 被静默丢弃，这是一个好方法，但是也导致不能发送图片。所以必须修改Backend。

参考：claude-code#31208, Kiro#6292, Cline#2146, modelcontextprotocol/servers#1638

## 数据流

```
MCP Server → ImageContent(base64)
    ↓
MCPClient.parseToolResult()
    ├─ text       → functionResponse → LLM 上下文
    └─ attachments → onAttachments 回调 → Backend.emit('attachments')
                                              ↓
                                   平台层 → sendPhoto / sendFile → 用户
```

## 向后兼容

- `ToolHandler` 签名 `Promise<unknown>` 不变，MCPToolResult 在 scheduler 层进行类型识别
- 现有 `__response` / `__parts` 约定不受影响（判断顺序：MCPToolResult → RichResult → 普通结果）
- 未监听 `attachments` 事件的平台无任何影响

## 其他平台复用

各平台只需监听 `backend.on('attachments')` 并实现各自发送方法：

| 平台 | 状态 |
|------|------|
| Telegram | ✅ 本 PR |
| Web | 已有 `assistant:content` 链路 |
| Lark | `sendImage` 已存在，待接入 |
| Discord / QQ | 待实现 |
