### PR TITLE
feat(skill,telegram): Skill 系统完整实现 + Telegram inline keyboard 交互

### DIFF
--- a/data/configs.example/system.yaml
+++ b/data/configs.example/system.yaml
@@ -27,3 +27,45 @@ maxRetries: 3
 #   response_<timestamp>.json  — 非流式响应原文
 #   response_<timestamp>.txt   — 流式响应原文（SSE）
 # logRequests: true
+
+# Skill 注入引导词模板（可选）
+# 启用的 Skill 注入到 LLM 时，会用引导词包裹，帮助 LLM 理解这些内容的身份和边界。
+# 模板中用 {{SKILL}} 标记 Skill 内容的插入位置。
+#
+# 不设置时使用内置默认引导词（推荐）。
+# 设为空字符串 "" 则不添加任何引导词，直接拼接原始 Skill 内容。
+#
+# 默认引导词格式：
+#   ===== ACTIVE SKILLS =====
+#   The following skills are currently active and provide specialized knowledge and instructions:
+#   ===== SKILL: <name> =====
+#   （Skill 内容）
+#   ===== END: <name> =====
+#
+# 自定义示例：
+# skillPreamble: |
+#   以下是当前激活的技能模块，请参考其中的指令执行任务：
+#   {{SKILL}}
+
+# Skill 定义（按需加载的提示词模块）
+# 启用的 Skill 内容会拼接到用户消息末尾
+# 名称规则：仅允许 ASCII 字母、数字、下划线、连字符，最长 64 字符
+#
+# 除了在此处内联定义，也可以将 SKILL.md 放在以下目录：
+#   ~/.iris/skills/<name>/SKILL.md    — 全局 Skill
+#   .agents/skills/<name>/SKILL.md    — 项目级 Skill（cwd 下）
+# 文件格式遵循 Agent Skills 开放标准（YAML frontmatter + Markdown 正文）
+# 同名时此处的内联定义优先于文件系统中的定义
+# skills:
+#   code-review:
+#     description: "代码审查专家"
+#     content: |
+#       你是一个代码审查专家。请对用户的代码进行详细审查，
+#       关注代码质量、安全性、性能和可维护性。
+#     enabled: true
+#
+#   translator:
+#     description: "中英翻译助手"
+#     content: |
+#       请将用户的内容翻译为对应的另一种语言（中→英 或 英→中）。
+#       保持原文的语气和风格。

--- a/data/configs.example/tools.yaml
+++ b/data/configs.example/tools.yaml
@@ -186,6 +186,9 @@ shell:
 sub_agent:
   autoApprove: false
 
+toggle_skills:
+  autoApprove: true
+
 # ─────────────────────────────────────────────────────────────
 # Computer Use 工具配置（需在 computer_use.yaml 中启用）
 # ─────────────────────────────────────────────────────────────

--- a/deploy/windows/install.bat
+++ b/deploy/windows/install.bat
@@ -1,4 +1,4 @@
-﻿@echo off
+@echo off
 chcp 65001 >nul 2>&1
 title Iris Installer
 setlocal EnableDelayedExpansion
@@ -224,4 +224,3 @@ echo 安装失败，请检查以上错误信息。
 pause
 exit /b 1
 
-﻿

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -36,6 +36,7 @@ import { SubAgentTypeRegistry, buildSubAgentGuidance, createSubAgentTool } from 
 import { ModeRegistry, DEFAULT_MODE, DEFAULT_MODE_NAME } from './modes';
 import { PromptAssembler } from './prompt/assembler';
 import { createHistorySearchTool } from './tools/internal/history_search';
+import { createManageSkillsTool } from './tools/internal/manage_skills';
 import { DEFAULT_SYSTEM_PROMPT } from './prompt/templates/default';
 import { Backend } from './core/backend';
 import type { StorageProvider } from './storage/base';
@@ -253,6 +254,8 @@ export async function bootstrap(options?: BootstrapOptions): Promise<BootstrapRe
     maxRecentScreenshots: config.computerUse?.maxRecentScreenshots,
     summaryModelName: config.llm.summaryModelName,
     summaryConfig: config.summary,
+    skills: config.system.skills,
+    skillPreamble: config.system.skillPreamble,
   }, memory, modeRegistry);
 
   // 注册子代理工具（需要 backend 引用；无类型定义时跳过）
@@ -271,6 +274,30 @@ export async function bootstrap(options?: BootstrapOptions): Promise<BootstrapRe
     getStorage: () => backend.getStorage(),
     getSessionId: () => backend.getActiveSessionId(),
   }));
+
+  // 注册 Skill 管理工具（toggle_skills 风格，仅在配置了 Skill 时注册）
+  // 工具声明中包含每个 Skill 的 name 和 description，LLM 从声明即可了解所有可用 Skill。
+  // Skill 列表或启用状态变化时，通过回调重新注册工具以更新声明中的参数。
+  if (config.system.skills?.length) {
+    const rebuildSkillsTool = () => {
+      const skillsList = backend.listSkills();
+      if (skillsList.length > 0) {
+        // 有 Skill 时注册/更新 toggle_skills 工具
+        tools.register(createManageSkillsTool({
+          getBackend: () => backend,
+        }));
+      } else {
+        // 无 Skill 时注销工具，避免空参数列表混淆 LLM
+        tools.unregister('toggle_skills');
+      }
+    };
+
+    // 初始注册
+    rebuildSkillsTool();
+
+    // 注册回调：Skill 列表或启用状态变化时自动重建工具声明
+    backend.setOnSkillsChanged(rebuildSkillsTool);
+  }
 
   // 将插件钩子注入 Backend
   const eventBus = new PluginEventBus();

--- a/src/config/embedded-defaults.ts
+++ b/src/config/embedded-defaults.ts
@@ -77,6 +77,8 @@ shell:
   autoApprove: false
 sub_agent:
   autoApprove: false
+toggle_skills:
+  autoApprove: true
 `,
 
   'memory.yaml': `# 记忆配置

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,7 +19,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { configDir as globalConfigDir, dataDir, projectRoot } from '../paths';
+import { configDir as globalConfigDir, dataDir as globalDataDir, projectRoot } from '../paths';
 import { EMBEDDED_CONFIG_DEFAULTS } from './embedded-defaults';
 import type { AgentPaths } from '../paths';
 import { AppConfig } from './types';
@@ -82,7 +82,7 @@ export function findConfigFile(customConfigDir?: string): string {
 
     // 初始化全局配置时，同时拷贝 agents.yaml 和示例 agent 配置
     if (!customConfigDir) {
-      initAgentsData(projectRoot, dataDir);
+      initAgentsData(projectRoot, globalDataDir);
     }
 
     console.log('[Iris] 请编辑配置文件（至少填写 LLM API Key）后重新启动。');
@@ -99,7 +99,7 @@ export function findConfigFile(customConfigDir?: string): string {
 
   // 初始化全局配置时，同时尝试拷贝 agents 数据（若源文件可用）
   if (!customConfigDir) {
-    initAgentsData(projectRoot, dataDir);
+    initAgentsData(projectRoot, globalDataDir);
   }
 
   console.log(`[Iris] 已初始化配置目录: ${targetDir}`);
@@ -116,6 +116,8 @@ export function findConfigFile(customConfigDir?: string): string {
 export function loadConfig(customConfigDir?: string, agentPaths?: AgentPaths): AppConfig {
   const configsDir = findConfigFile(customConfigDir);
   const data = loadRawConfigDir(configsDir);
+  // Skill 文件系统扫描需要数据目录：Agent 模式用 agentPaths.dataDir，否则用全局 dataDir
+  const effectiveDataDir = agentPaths?.dataDir || globalDataDir;
 
   return {
     llm: parseLLMConfig(data.llm),
@@ -123,7 +125,7 @@ export function loadConfig(customConfigDir?: string, agentPaths?: AgentPaths): A
     platform: parsePlatformConfig(data.platform),
     storage: parseStorageConfig(data.storage, agentPaths),
     tools: parseToolsConfig(data.tools),
-    system: parseSystemConfig(data.system),
+    system: parseSystemConfig(data.system, effectiveDataDir),
     memory: parseMemoryConfig(data.memory, agentPaths),
     mcp: parseMCPConfig(data.mcp),
     modes: parseModeConfig(data.modes),

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -3,12 +3,14 @@
  */
 
 import { Backend } from '../core/backend';
+import { dataDir } from '../paths';
 import { createLLMRouter } from '../llm/factory';
 import { OCRService, type OCRProvider } from '../ocr';
 import { parseLLMConfig } from './llm';
 import { parseOCRConfig } from './ocr';
 import { parseToolsConfig } from './tools';
 import { parseMCPConfig } from './mcp';
+import { parseSystemConfig } from './system';
 import { DEFAULT_SYSTEM_PROMPT } from '../prompt/templates/default';
 import { createMCPManager, MCPManager } from '../mcp';
 import { ToolRegistry } from '../tools/registry';
@@ -70,6 +72,8 @@ export async function applyRuntimeConfigReload(
   const currentModel = newRouter.getCurrentModelInfo();
 
   context.backend.reloadLLM(newRouter);
+  // 解析 system 配置（提取 skills 和 skillPreamble，避免重复调用 parseSystemConfig）
+  const systemConfig = parseSystemConfig(mergedConfig.system, dataDir);
   context.backend.reloadConfig({
     stream: mergedConfig.system?.stream,
     maxToolRounds: mergedConfig.system?.maxToolRounds,
@@ -79,6 +83,9 @@ export async function applyRuntimeConfigReload(
     systemPrompt: mergedConfig.system?.systemPrompt || DEFAULT_SYSTEM_PROMPT,
     currentLLMConfig: newRouter.getCurrentConfig(),
     ocrService: await createReloadOCRProvider(context, ocrConfig),
+    // 热重载 Skill 定义和引导词模板
+    skills: systemConfig.skills,
+    skillPreamble: systemConfig.skillPreamble,
   });
 
   const tools = context.backend.getTools();

--- a/src/config/skill-loader.ts
+++ b/src/config/skill-loader.ts
@@ -1,0 +1,143 @@
+/**
+ * Skill 文件系统加载器
+ *
+ * 扫描指定目录下的 SKILL.md 文件，解析 YAML frontmatter，
+ * 转换为 SkillDefinition 数组。
+ *
+ * 遵循 Agent Skills 开放标准：
+ *   - 每个 Skill 是一个目录，内含 SKILL.md 作为入口
+ *   - SKILL.md 以 YAML frontmatter 开头（--- 包裹），后跟 Markdown 正文
+ *   - frontmatter 中 name 和 description 为标准字段
+ *   - Markdown 正文即为 Skill 的 content
+ *
+ * 扫描路径（按优先级从高到低）：
+ *   1. ~/.iris/skills/<name>/SKILL.md       — 全局 Skill
+ *   2. .agents/skills/<name>/SKILL.md       — 项目级 Skill（cwd 下）
+ *
+ * 与 system.yaml 中的 skills 配置合并时，YAML 配置优先（同名覆盖）。
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { SkillDefinition } from './types';
+
+/** Skill 名称校验：仅允许 ASCII 字母、数字、下划线、连字符，1-64 字符 */
+const SKILL_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+
+/**
+ * 解析单个 SKILL.md 文件。
+ *
+ * 格式：
+ *   ---
+ *   name: my-skill
+ *   description: 做什么用的
+ *   ---
+ *   Markdown 正文（即 content）
+ *
+ * 如果 frontmatter 中没有 name，则使用目录名。
+ * 如果解析失败，返回 undefined。
+ */
+function parseSkillMd(filePath: string, dirName: string): SkillDefinition | undefined {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+
+    // 匹配 YAML frontmatter：以 --- 开头和结尾
+    const fmMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+    if (!fmMatch) {
+      // 没有 frontmatter，整个文件作为 content，目录名作为 name
+      const content = raw.trim();
+      if (!content) return undefined;
+      const name = dirName;
+      if (!SKILL_NAME_RE.test(name)) {
+        console.warn(`[Iris] Skill 目录名 "${name}" 不合法（需匹配 ${SKILL_NAME_RE}），已跳过: ${filePath}`);
+        return undefined;
+      }
+      return { name, content };
+    }
+
+    const frontmatterText = fmMatch[1];
+    const content = fmMatch[2].trim();
+    if (!content) return undefined;
+
+    // 简易 YAML 解析（不引入 yaml 依赖，仅处理简单键值对）
+    const fields: Record<string, string> = {};
+    for (const line of frontmatterText.split('\n')) {
+      const kv = line.match(/^(\w[\w-]*)\s*:\s*(.+)$/);
+      if (kv) {
+        fields[kv[1]] = kv[2].replace(/^["']|["']$/g, '').trim();
+      }
+    }
+
+    const name = fields.name || dirName;
+    if (!SKILL_NAME_RE.test(name)) {
+      console.warn(`[Iris] Skill "${name}" 名称不合法（需匹配 ${SKILL_NAME_RE}），已跳过: ${filePath}`);
+      return undefined;
+    }
+
+    return {
+      name,
+      description: fields.description || undefined,
+      content,
+      enabled: fields.enabled === 'true',
+    };
+  } catch {
+    // 读取或解析失败，静默跳过
+    return undefined;
+  }
+}
+
+/**
+ * 扫描指定目录下的 Skill（一级子目录中的 SKILL.md）。
+ *
+ * 目录结构：
+ *   skillsDir/
+ *     my-skill/
+ *       SKILL.md
+ *     another-skill/
+ *       SKILL.md
+ */
+function scanSkillsDir(skillsDir: string): SkillDefinition[] {
+  if (!fs.existsSync(skillsDir)) return [];
+
+  const results: SkillDefinition[] = [];
+  try {
+    const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const skillMdPath = path.join(skillsDir, entry.name, 'SKILL.md');
+      if (!fs.existsSync(skillMdPath)) continue;
+
+      const skill = parseSkillMd(skillMdPath, entry.name);
+      if (skill) results.push(skill);
+    }
+  } catch {
+    // 目录不可读，静默跳过
+  }
+  return results;
+}
+
+/**
+ * 从文件系统加载 Skill 定义。
+ *
+ * 扫描路径：
+ *   1. dataDir/skills/     — 全局 Skill（~/.iris/skills/）
+ *   2. cwd/.agents/skills/ — 项目级 Skill
+ *
+ * @param dataDir  数据目录（默认 ~/.iris/）
+ * @returns 扫描到的 SkillDefinition 数组（项目级优先于全局）
+ */
+export function loadSkillsFromFilesystem(dataDir: string): SkillDefinition[] {
+  const globalDir = path.join(dataDir, 'skills');
+  const projectDir = path.join(process.cwd(), '.agents', 'skills');
+
+  // 全局 Skill 先加载，项目级后加载（同名时项目级覆盖全局）
+  const globalSkills = scanSkillsDir(globalDir);
+  const projectSkills = scanSkillsDir(projectDir);
+
+  // 合并：项目级覆盖全局同名
+  const merged = new Map<string, SkillDefinition>();
+  for (const s of globalSkills) merged.set(s.name, s);
+  for (const s of projectSkills) merged.set(s.name, s);
+
+  return Array.from(merged.values());
+}

--- a/src/config/system.ts
+++ b/src/config/system.ts
@@ -1,17 +1,64 @@
 /**
  * 系统级配置解析
+ *
+ * 支持两种 Skill 来源：
+ *   1. system.yaml 中的 skills 字段（内联定义）
+ *   2. 文件系统扫描（~/.iris/skills/ 和 .agents/skills/）
+ *
+ * 合并优先级：YAML 内联定义 > 项目级文件 > 全局文件
  */
 
-import { SystemConfig } from './types';
+import { SystemConfig, SkillDefinition } from './types';
+import { loadSkillsFromFilesystem } from './skill-loader';
 
-export function parseSystemConfig(raw: any = {}): SystemConfig {
+/** Skill 名称校验：仅允许 ASCII 字母、数字、下划线、连字符，1-64 字符 */
+const SKILL_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+
+export function parseSystemConfig(raw: any = {}, dataDir?: string): SystemConfig {
+  // 解析 system.yaml 中的内联 skills 定义
+  let yamlSkills: SkillDefinition[] = [];
+  if (raw.skills && typeof raw.skills === 'object' && !Array.isArray(raw.skills)) {
+    yamlSkills = Object.entries(raw.skills)
+      .filter(([, v]) => v && typeof v === 'object' && typeof (v as any).content === 'string')
+      .filter(([name]) => {
+        if (!SKILL_NAME_RE.test(name)) { console.warn(`[Iris] Skill "${name}" 名称不合法（需匹配 ${SKILL_NAME_RE}），已跳过`); return false; }
+        return true;
+      })
+      .map(([name, v]) => ({
+        name,
+        description: typeof (v as any).description === 'string' ? (v as any).description : undefined,
+        content: (v as any).content as string,
+        enabled: (v as any).enabled === true,
+      }));
+  }
+
+  // 从文件系统扫描 SKILL.md（仅在提供了 dataDir 时扫描）
+  let fsSkills: SkillDefinition[] = [];
+  if (dataDir) {
+    fsSkills = loadSkillsFromFilesystem(dataDir);
+  }
+
+  // 合并：文件系统 Skill 打底，YAML 内联定义覆盖同名条目
+  let skills: SkillDefinition[] | undefined;
+  if (fsSkills.length > 0 || yamlSkills.length > 0) {
+    const merged = new Map<string, SkillDefinition>();
+    for (const s of fsSkills) merged.set(s.name, s);
+    for (const s of yamlSkills) merged.set(s.name, s);  // YAML 覆盖同名
+    skills = Array.from(merged.values());
+    if (skills.length === 0) skills = undefined;
+  }
+
   return {
     systemPrompt: raw.systemPrompt ?? '',
     maxToolRounds: raw.maxToolRounds ?? 200,
     stream: raw.stream ?? true,
+    // skillPreamble: Skill 注入引导词模板，支持 {{SKILL}} 占位符。
+    // 仅在用户显式配置时传入，undefined 表示使用内置默认引导词。
+    skillPreamble: typeof raw.skillPreamble === 'string' ? raw.skillPreamble : undefined,
     retryOnError: raw.retryOnError ?? true,
     maxRetries: raw.maxRetries ?? 3,
     maxAgentDepth: raw.maxAgentDepth ?? 3,
     logRequests: raw.logRequests ?? false,
+    skills,
   };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -149,6 +149,22 @@ export interface ToolsConfig {
   disabledTools?: string[];
 }
 
+/** Skill 定义（按需加载的提示词模块） */
+export interface SkillDefinition {
+  /**
+   * Skill 名称（唯一标识，从 YAML 键名解析）。
+   * 命名规则：仅允许 ASCII 字母、数字、下划线、连字符，最长 64 字符。
+   * 正则：^[a-zA-Z0-9_-]{1,64}$
+   */
+  name: string;
+  /** Skill 描述 */
+  description?: string;
+  /** Skill 提示词内容（启用后拼接到用户消息末尾） */
+  content: string;
+  /** 是否默认启用，默认 false */
+  enabled?: boolean;
+}
+
 export interface SystemConfig {
   systemPrompt: string;
   maxToolRounds: number;
@@ -163,6 +179,18 @@ export interface SystemConfig {
   defaultMode?: string;
   /** 是否记录 LLM 请求日志到文件，默认 false */
   logRequests?: boolean;
+  /** Skill 定义列表（可选） */
+  skills?: SkillDefinition[];
+  /**
+   * Skill 注入引导词模板（可选）。
+   *
+   * 用 {{SKILL}} 占位符标记 Skill 内容的插入位置。
+   * 启用的 Skill 内容会替换 {{SKILL}} 后拼接到用户消息末尾。
+   *
+   * 不设置时使用内置默认引导词。
+   * 设为空字符串 "" 则不添加任何引导词，直接拼接原始 Skill 内容（旧行为）。
+   */
+  skillPreamble?: string;
 }
 
 export interface MemoryConfig {

--- a/src/core/backend.ts
+++ b/src/core/backend.ts
@@ -14,7 +14,7 @@ import { EventEmitter } from 'events';
 import * as path from 'path';
 import * as fs from 'fs';
 import { spawnSync } from 'child_process';
-import type { LLMConfig, ToolsConfig, ToolPolicyConfig } from '../config/types';
+import type { LLMConfig, ToolsConfig, ToolPolicyConfig, SkillDefinition } from '../config/types';
 import { LLMRouter } from '../llm/router';
 import { supportsVision as llmSupportsVision, isDocumentMimeType, supportsNativePDF, supportsNativeOffice } from '../llm/vision';
 import type { PluginHook } from '../plugins/types';
@@ -185,6 +185,10 @@ export interface BackendConfig {
   summaryModelName?: string;
   /** 上下文压缩提示词配置 */
   summaryConfig?: SummaryConfig;
+  /** Skill 定义列表 */
+  skills?: SkillDefinition[];
+  /** Skill 注入引导词模板，支持 {{SKILL}} 占位符；undefined 使用内置默认 */
+  skillPreamble?: string;
 }
 
 export interface BackendEvents {
@@ -258,6 +262,23 @@ export class Backend extends EventEmitter {
 
   /** 插件钩子列表 */
   private pluginHooks: PluginHook[] = [];
+  /** Skill 定义列表 */
+  private skills: SkillDefinition[] = [];
+  /** 当前启用的 Skill 名称集合 */
+  private enabledSkills = new Set<string>();
+  /**
+   * Skill 注入引导词模板。
+   * 用 {{SKILL}} 标记 Skill 内容的插入位置。
+   * undefined 表示使用内置默认引导词。
+   * 空字符串 "" 表示不添加引导词（旧行为：直接拼接 Skill 内容）。
+   */
+  private skillPreamble?: string;
+
+  /**
+   * Skill 列表或启用状态变化时的回调。
+   * 由外部（bootstrap）设置，用于在 Skill 变化时重建 toggle_skills 工具声明。
+   */
+  private _onSkillsChanged?: () => void;
 
   constructor(
     router: LLMRouter,
@@ -286,6 +307,16 @@ export class Backend extends EventEmitter {
     this.maxRecentScreenshots = config?.maxRecentScreenshots ?? 3;
     this.summaryModelName = config?.summaryModelName;
     this.summaryConfig = config?.summaryConfig;
+
+    // 初始化 Skill
+    if (config?.skills) {
+      this.skills = config.skills;
+      for (const s of config.skills) {
+        if (s.enabled) this.enabledSkills.add(s.name);
+      }
+    }
+    // 初始化 Skill 引导词模板
+    this.skillPreamble = config?.skillPreamble;
 
     this.toolLoopConfig = {
       maxRounds: config?.maxToolRounds ?? 200,
@@ -708,6 +739,128 @@ export class Backend extends EventEmitter {
     return this.modeRegistry;
   }
 
+  // ============ Skill 管理 ============
+
+  /** 注册 Skill 列表变化回调（用于重建 toggle_skills 工具声明） */
+  setOnSkillsChanged(callback: () => void): void {
+    this._onSkillsChanged = callback;
+  }
+
+  /** 列出所有已定义的 Skill 及其启用状态 */
+  listSkills(): { name: string; description?: string; enabled: boolean }[] {
+    return this.skills.map(s => ({
+      name: s.name,
+      description: s.description,
+      enabled: this.enabledSkills.has(s.name),
+    }));
+  }
+
+  /** 启用指定 Skill，返回是否成功（Skill 不存在时返回 false） */
+  enableSkill(name: string): boolean {
+    if (!this.skills.some(s => s.name === name)) return false;
+    this.enabledSkills.add(name);
+    // 通知外部 Skill 状态已变化，需重建工具声明
+    this._onSkillsChanged?.();
+    return true;
+  }
+
+  /** 禁用指定 Skill，返回是否成功（Skill 不存在时返回 false） */
+  disableSkill(name: string): boolean {
+    if (!this.skills.some(s => s.name === name)) return false;
+    this.enabledSkills.delete(name);
+    // 通知外部 Skill 状态已变化，需重建工具声明
+    this._onSkillsChanged?.();
+    return true;
+  }
+
+  /** 切换指定 Skill 的启用状态，返回切换后的状态（Skill 不存在时返回 undefined） */
+  toggleSkill(name: string): boolean | undefined {
+    if (!this.skills.some(s => s.name === name)) return undefined;
+    if (this.enabledSkills.has(name)) {
+      this.enabledSkills.delete(name);
+      // 通知外部 Skill 状态已变化，需重建工具声明
+      this._onSkillsChanged?.();
+      return false;
+    } else {
+      this.enabledSkills.add(name);
+      // 通知外部 Skill 状态已变化，需重建工具声明
+      this._onSkillsChanged?.();
+      return true;
+    }
+  }
+
+  // ============ Mode 管理 ============
+
+  /** 列出所有已注册的 Mode */
+  listModes(): { name: string; description?: string; current: boolean }[] {
+    if (!this.modeRegistry) return [];
+    return this.modeRegistry.getAll().map(m => ({
+      name: m.name,
+      description: m.description,
+      current: m.name === this.defaultMode,
+    }));
+  }
+
+  /** 切换当前 Mode，返回是否成功（Mode 不存在时返回 false） */
+  switchMode(name: string): boolean {
+    if (!this.modeRegistry) return false;
+    const mode = this.modeRegistry.get(name);
+    if (!mode) return false;
+    this.defaultMode = name;
+    logger.info(`Mode 已切换: ${name}`);
+    return true;
+  }
+
+  /** 获取当前 Mode 名称 */
+  getCurrentMode(): string | undefined {
+    return this.defaultMode;
+  }
+
+  /**
+   * 构建 Skill 注入文本（内部使用）。
+   *
+   * 将所有已启用的 Skill 按结构化格式拼装，并使用 skillPreamble 引导词包裹。
+   * 引导词中的 {{SKILL}} 占位符会被替换为实际的 Skill 块。
+   *
+   * 返回 undefined 表示没有启用的 Skill，不需要注入。
+   */
+  private buildSkillInjection(): string | undefined {
+    // 收集当前启用的 Skill
+    const activeSkills = this.skills.filter(s => this.enabledSkills.has(s.name));
+    if (activeSkills.length === 0) return undefined;
+
+    // 按 Skill 名称分组，用明确的标记分隔每个 Skill 块
+    const skillBlocks = activeSkills.map(s => {
+      const header = `===== SKILL: ${s.name} =====`;
+      const footer = `===== END: ${s.name} =====`;
+      return `${header}\n\n${s.content}\n\n${footer}`;
+    }).join('\n\n');
+
+    // 确定引导词模板：
+    //   - undefined → 使用内置默认引导词
+    //   - 空字符串 "" → 不添加引导词，直接返回 Skill 块（旧行为）
+    //   - 非空字符串 → 使用用户自定义模板
+    const preamble = this.skillPreamble;
+    if (preamble === undefined) {
+      // 内置默认引导词，参考 Limcode 的格式
+      return (
+        '===== ACTIVE SKILLS =====\n\n' +
+        'The following skills are currently active and provide specialized knowledge and instructions:\n\n' +
+        skillBlocks
+      );
+    }
+    if (preamble === '') {
+      // 用户显式设为空字符串，不添加引导词
+      return skillBlocks;
+    }
+    // 用户自定义模板，用 {{SKILL}} 占位符标记插入位置
+    if (preamble.includes('{{SKILL}}')) {
+      return preamble.replace('{{SKILL}}', skillBlocks);
+    }
+    // 用户提供了引导词但没写 {{SKILL}}，把 Skill 块拼接到引导词后面
+    return preamble + '\n\n' + skillBlocks;
+  }
+
   /** 获取当前活动模型名称 */
   getCurrentModelName(): string {
     return this.router.getCurrentModelName();
@@ -796,6 +949,9 @@ export class Backend extends EventEmitter {
     currentLLMConfig?: LLMConfig;
     ocrService?: OCRProvider;
     maxRecentScreenshots?: number;
+    skills?: SkillDefinition[];
+    /** Skill 注入引导词模板（热重载时更新） */
+    skillPreamble?: string;
   }): void {
     if (opts.stream !== undefined) this.stream = opts.stream;
     if (opts.maxToolRounds !== undefined) this.toolLoopConfig.maxRounds = opts.maxToolRounds;
@@ -806,6 +962,17 @@ export class Backend extends EventEmitter {
     if ('currentLLMConfig' in opts) this.currentLLMConfig = opts.currentLLMConfig;
     if ('ocrService' in opts) this.ocrService = opts.ocrService;
     if (opts.maxRecentScreenshots !== undefined) this.maxRecentScreenshots = opts.maxRecentScreenshots;
+    if (opts.skills !== undefined) {
+      this.skills = opts.skills;
+      this.enabledSkills.clear();
+      for (const s of opts.skills) {
+        if (s.enabled) this.enabledSkills.add(s.name);
+      }
+      // 通知外部 Skill 列表已变化，需重建 toggle_skills 工具声明
+      this._onSkillsChanged?.();
+    }
+    // 热重载 Skill 引导词模板
+    if ('skillPreamble' in opts) this.skillPreamble = opts.skillPreamble;
     logger.info(`配置已热重载: stream=${this.stream} maxToolRounds=${this.toolLoopConfig.maxRounds} toolPolicies=${Object.keys(this.toolLoopConfig.toolsConfig.permissions).length}`);
   }
 
@@ -891,7 +1058,13 @@ export class Backend extends EventEmitter {
     const history = this.prepareHistoryForLLM(storedHistory);
     const isNewSession = storedHistory.length === 0;
     const userText = extractText(llmUserParts);
-    history.push({ role: 'user', parts: llmUserParts });
+
+    // 注入启用的 Skill 内容（拼接到用户消息末尾，不存入持久化历史）
+    const skillInjection = this.buildSkillInjection();
+    const finalLlmParts = skillInjection
+      ? [...llmUserParts, { text: '\n\n' + skillInjection }]
+      : llmUserParts;
+    history.push({ role: 'user', parts: finalLlmParts });
 
     // 2. 构建 per-request 额外上下文
     let extraParts: Part[] | undefined;

--- a/src/platforms/telegram/client.ts
+++ b/src/platforms/telegram/client.ts
@@ -87,6 +87,35 @@ export class TelegramClient {
     return msg.message_id;
   }
 
+  /**
+   * 发送带 inline keyboard 的消息，返回 message_id。
+   * 用于 /model、/session、/mode、/skill 命令的列表展示。
+   */
+  async sendMessageWithKeyboard(
+    target: TelegramSessionTarget,
+    text: string,
+    keyboard: Array<Array<{ text: string; callback_data: string }>>,
+  ): Promise<number> {
+    const extra: Record<string, unknown> = {
+      reply_markup: { inline_keyboard: keyboard },
+    };
+    if (target.threadId != null) {
+      extra.message_thread_id = target.threadId;
+    }
+    const msg = await this.bot.api.sendMessage(target.chatId, text, extra);
+    return msg.message_id;
+  }
+
+  /** 注册 callback_query 处理器 */
+  onCallbackQuery(handler: (ctx: any) => void): void {
+    this.bot.on('callback_query:data', handler);
+  }
+
+  /** 回答 callback_query（消除 loading 动画） */
+  async answerCallbackQuery(callbackQueryId: string, text?: string): Promise<void> {
+    await this.bot.api.answerCallbackQuery(callbackQueryId, text ? { text } : {});
+  }
+
   async sendText(target: TelegramSessionTarget, text: string, options: TelegramSendTextOptions = {}): Promise<void> {
     const chunks = splitText(text, TELEGRAM_MESSAGE_MAX_LENGTH);
     for (const chunk of chunks) {

--- a/src/platforms/telegram/commands.ts
+++ b/src/platforms/telegram/commands.ts
@@ -21,6 +21,8 @@ export const TELEGRAM_BOT_COMMANDS = [
   { command: 'flush', description: '立即处理缓冲中的消息' },
   { command: 'undo', description: '撤销上一轮对话' },
   { command: 'redo', description: '恢复撤销的对话' },
+  { command: 'skill', description: '查看或切换 Skill' },
+  { command: 'mode', description: '查看或切换 Mode（提示词模式）' },
   { command: 'help', description: '显示帮助' },
 ];
 

--- a/src/platforms/telegram/index.ts
+++ b/src/platforms/telegram/index.ts
@@ -22,6 +22,7 @@ import {
   TelegramConfig,
   TelegramPendingMessage,
   TelegramSessionTarget,
+  buildTelegramSessionTarget,
 } from './types';
 import type { ToolAttachment } from '../../types';
 
@@ -98,6 +99,7 @@ export class TelegramPlatform extends PlatformAdapter {
   async start(): Promise<void> {
     this.setupBackendListeners();
     this.client.onMessage((ctx) => this.handleMessage(ctx));
+    this.client.onCallbackQuery((ctx) => this.handleCallbackQuery(ctx));
     await this.client.start();
     logger.info('Telegram 平台已启动');
   }
@@ -450,6 +452,86 @@ export class TelegramPlatform extends PlatformAdapter {
     }
   }
 
+  /**
+   * 处理 inline keyboard 按钮点击。
+   * callback_data 格式：`命令:参数`，例如 `model:gpt-4`、`session:3`、`skill:code-review`、`mode:code`。
+   */
+  private async handleCallbackQuery(ctx: any): Promise<void> {
+    try {
+      const data = ctx.callbackQuery?.data as string | undefined;
+      const chat = ctx.callbackQuery?.message?.chat;
+      const messageId = ctx.callbackQuery?.message?.message_id;
+      const callbackQueryId = ctx.callbackQuery?.id;
+      const threadId = ctx.callbackQuery?.message?.message_thread_id;
+
+      if (!data || !chat || !messageId || !callbackQueryId) return;
+
+      const target = buildTelegramSessionTarget({
+        chatId: chat.id,
+        isPrivate: chat.type === 'private',
+        threadId: typeof threadId === 'number' ? threadId : undefined,
+      });
+
+      const colonIdx = data.indexOf(':');
+      if (colonIdx < 0) return;
+      const command = data.substring(0, colonIdx);
+      const arg = data.substring(colonIdx + 1);
+
+      let resultText = '';
+
+      switch (command) {
+        case 'model': {
+          try {
+            const result = this.backend.switchModel(arg);
+            resultText = `✅ 模型已切换为 ${result.modelName} → ${result.modelId}`;
+          } catch {
+            resultText = `❌ 未找到模型 "${arg}"。`;
+          }
+          break;
+        }
+
+        case 'session': {
+          const index = parseInt(arg, 10);
+          const metas = await this.backend.listSessionMetas();
+          if (isNaN(index) || index < 1 || index > metas.length) {
+            resultText = `❌ 会话编号无效。`;
+          } else {
+            const meta = metas[index - 1];
+            this.activeSessions.set(target.chatKey, meta.id);
+            resultText = `✅ 已切换到会话：${meta.title || '(无标题)'}`;
+          }
+          break;
+        }
+
+        case 'mode': {
+          const ok = this.backend.switchMode(arg);
+          resultText = ok ? `✅ 已切换到 Mode "${arg}"。` : `❌ 未找到 Mode "${arg}"。`;
+          break;
+        }
+
+        case 'skill': {
+          const result = this.backend.toggleSkill(arg);
+          if (result === undefined) {
+            resultText = `❌ 未找到 Skill "${arg}"。`;
+          } else {
+            resultText = `✅ Skill "${arg}" 已${result ? '启用' : '禁用'}。`;
+          }
+          break;
+        }
+
+        default:
+          resultText = `❌ 未知操作: ${command}`;
+      }
+
+      // 编辑原消息为结果文本（去掉 inline keyboard）
+      await this.client.editText(target, messageId, resultText);
+      // 回答 callback query
+      await this.client.answerCallbackQuery(callbackQueryId);
+    } catch (err) {
+      logger.error('处理 callback query 时出错:', err);
+    }
+  }
+
   // ---- Slash 命令 ----
 
   private async handleCommand(text: string, cs: TelegramChatState): Promise<boolean> {
@@ -483,10 +565,17 @@ export class TelegramPlatform extends PlatformAdapter {
           }
         } else {
           const models = this.backend.listModels();
-          const lines = models.map((m) =>
-            `${m.current ? '👉 ' : '   '}${m.modelName} → ${m.modelId}`
+          // 构建 inline keyboard：每个模型一个按钮，每行一个
+          const keyboard = models.map(m => [{
+            text: `${m.current ? '👉 ' : ''}${m.modelName}`,
+            callback_data: `model:${m.modelName}`,
+          }]);
+          const currentModel = models.find(m => m.current);
+          await this.client.sendMessageWithKeyboard(
+            cs.target,
+            `🤖 当前模型：${currentModel?.modelName ?? '未知'}\n选择要切换的模型：`,
+            keyboard,
           );
-          await reply(`当前可用模型：\n${lines.join('\n')}\n\n切换模型请发送 /model 模型名`);
         }
         return true;
       }
@@ -514,14 +603,16 @@ export class TelegramPlatform extends PlatformAdapter {
             return true;
           }
           const display = metas.slice(0, 20);
-          const lines = display.map((m, i) => {
-            const date = m.updatedAt
-              ? new Date(m.updatedAt).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' })
-              : '未知时间';
-            const current = m.id === cs.sessionId ? ' 👈' : '';
-            return `${i + 1}. ${m.title || '(无标题)'}  ${date}${current}`;
-          });
-          await reply(`📋 历史会话\n\n${lines.join('\n')}\n\n发送 /session 编号 切换`);
+          // 构建 inline keyboard：每个会话一个按钮
+          const keyboard = display.map((m, i) => [{
+            text: `${m.id === cs.sessionId ? '👉 ' : ''}${m.title || '(无标题)'}`,
+            callback_data: `session:${i + 1}`,
+          }]);
+          await this.client.sendMessageWithKeyboard(
+            cs.target,
+            '📋 选择要切换的会话：',
+            keyboard,
+          );
         }
         return true;
       }
@@ -591,6 +682,62 @@ export class TelegramPlatform extends PlatformAdapter {
 
         // 平台 UI 只回放最终可见文本，不重新调 LLM。
         await this.replayRedoResult(cs, redoResult.assistantText);
+        return true;
+      }
+
+      case 'skill':
+      case 'skills': {
+        const skills = this.backend.listSkills();
+        if (skills.length === 0) {
+          await reply('ℹ️ 未配置任何 Skill。请在 system.yaml 中添加。');
+          return true;
+        }
+        if (cmd.args) {
+          const result = this.backend.toggleSkill(cmd.args);
+          if (result === undefined) {
+            await reply(`❌ 未找到 Skill "${cmd.args}"。发送 /skill 查看可用列表。`);
+          } else {
+            await reply(`✅ Skill "${cmd.args}" 已${result ? '启用' : '禁用'}。`);
+          }
+        } else {
+          const keyboard = skills.map(s => [{
+            text: `${s.enabled ? '✅' : '⬜'} ${s.name}${s.description ? ` — ${s.description}` : ''}`,
+            callback_data: `skill:${s.name}`,
+          }]);
+          await this.client.sendMessageWithKeyboard(
+            cs.target,
+            '🧩 点击切换 Skill 的启用状态：',
+            keyboard,
+          );
+        }
+        return true;
+      }
+
+      case 'mode':
+      case 'modes': {
+        const modes = this.backend.listModes();
+        if (modes.length === 0) {
+          await reply('ℹ️ 未配置任何 Mode。请在 modes.yaml 中添加。');
+          return true;
+        }
+        if (cmd.args) {
+          const ok = this.backend.switchMode(cmd.args);
+          if (!ok) {
+            await reply(`❌ 未找到 Mode "${cmd.args}"。发送 /mode 查看可用列表。`);
+          } else {
+            await reply(`✅ 已切换到 Mode "${cmd.args}"。`);
+          }
+        } else {
+          const keyboard = modes.map(m => [{
+            text: `${m.current ? '👉 ' : ''}${m.name}${m.description ? ` — ${m.description}` : ''}`,
+            callback_data: `mode:${m.name}`,
+          }]);
+          await this.client.sendMessageWithKeyboard(
+            cs.target,
+            '🎭 选择要切换的 Mode：',
+            keyboard,
+          );
+        }
         return true;
       }
 

--- a/src/tools/internal/manage_skills.ts
+++ b/src/tools/internal/manage_skills.ts
@@ -1,0 +1,119 @@
+/**
+ * Skill 管理工具（toggle_skills 风格）
+ *
+ * 动态将每个已定义的 Skill 生成为工具声明中的 boolean 参数，
+ * 参数的 description 即为 Skill 的 description，让 LLM 从工具声明就能看到
+ * 所有可用 Skill 及其用途，无需额外调用 list 操作。
+ *
+ * 参考 Agent Skills 标准的渐进式披露（progressive disclosure）：
+ *   - Tier 1（始终可见）：name + description 通过工具参数声明暴露给 LLM（~50-100 token/skill）
+ *   - Tier 2（按需加载）：用户/LLM 启用 Skill 后，其完整 content 注入到后续对话
+ *
+ * 工具声明需要在 Skill 列表变化时重建（通过 rebuildDeclaration 方法）。
+ */
+
+import type { ToolDefinition, FunctionDeclaration } from '../../types';
+import type { Backend } from '../../core/backend';
+
+export interface ManageSkillsDeps {
+  getBackend: () => Backend;
+}
+
+/**
+ * 根据当前 Skill 列表动态构建工具的参数声明。
+ *
+ * 每个 Skill 映射为一个 boolean 参数：
+ *   - 参数名 = Skill name
+ *   - 参数 description = Skill description（若有）
+ *   - 设为 true 表示启用，false 表示禁用
+ *
+ * 这样 LLM 在查看工具声明时就能看到所有可用 Skill 的列表和说明，
+ * 无需额外调用 list 操作即可了解有什么 Skill。
+ */
+function buildDeclaration(
+  skills: { name: string; description?: string; enabled: boolean }[],
+): FunctionDeclaration {
+  // 构建参数 properties：每个 Skill 一个 boolean 参数
+  const properties: Record<string, { type: string; description: string }> = {};
+  for (const s of skills) {
+    properties[s.name] = {
+      type: 'boolean',
+      description: s.description || s.name,
+    };
+  }
+
+  return {
+    // 工具名称需满足 ^[a-zA-Z0-9_-]{1,64}$，以兼容 Claude 等模型
+    name: 'toggle_skills',
+    description:
+      'Toggle whether to send skill content to the conversation. ' +
+      'Skills are user-defined knowledge modules that provide specialized context and instructions. ' +
+      'Each parameter is a skill name - set to true to send content, false to stop sending. ' +
+      'The skill content will be included in subsequent messages. ' +
+      'Enable a skill when you need its specific content for the current task; ' +
+      'disable it when no longer needed to save conversation space.',
+    parameters: {
+      type: 'object',
+      properties,
+      required: [],
+    },
+  };
+}
+
+/**
+ * 创建 Skill 管理工具。
+ *
+ * 返回的 ToolDefinition 会在 Skill 列表变化时通过重新注册来更新声明。
+ * 调用方应在 Skill 列表变化（热重载等）后调用 createManageSkillsTool 并重新注册。
+ */
+export function createManageSkillsTool(deps: ManageSkillsDeps): ToolDefinition {
+  const backend = deps.getBackend();
+  const skills = backend.listSkills();
+
+  return {
+    declaration: buildDeclaration(skills),
+    handler: async (args) => {
+      const backend = deps.getBackend();
+      const results: { name: string; success: boolean; enabled: boolean; message: string }[] = [];
+
+      // 遍历所有传入的参数，每个都是一个 Skill 名称 → boolean
+      for (const [name, value] of Object.entries(args)) {
+        if (typeof value !== 'boolean') continue;
+
+        if (value) {
+          // 启用 Skill
+          const ok = backend.enableSkill(name);
+          if (ok) {
+            results.push({ name, success: true, enabled: true, message: `Skill "${name}" 已启用。` });
+          } else {
+            results.push({ name, success: false, enabled: false, message: `Skill "${name}" 不存在。` });
+          }
+        } else {
+          // 禁用 Skill
+          const ok = backend.disableSkill(name);
+          if (ok) {
+            results.push({ name, success: true, enabled: false, message: `Skill "${name}" 已禁用。` });
+          } else {
+            results.push({ name, success: false, enabled: false, message: `Skill "${name}" 不存在。` });
+          }
+        }
+      }
+
+      // 如果没有传入任何有效参数，返回当前状态列表（兼容旧行为）
+      if (results.length === 0) {
+        const currentSkills = backend.listSkills();
+        return {
+          skills: currentSkills.map(s => ({
+            name: s.name,
+            description: s.description ?? '',
+            enabled: s.enabled,
+          })),
+          message: '未指定任何 Skill 切换操作，已列出当前状态。',
+        };
+      }
+
+      return { results };
+    },
+    parallel: false,
+  };
+}


### PR DESCRIPTION
## 改动

### 1. Skill 系统完整实现
- 新增 `skill-loader.ts`：从文件系统扫描 `SKILL.md`，解析 YAML frontmatter
- 新增 `manage_skills.ts`（toggle_skills 工具）：动态将每个 Skill 生成为工具声明中的 boolean 参数，LLM 从工具声明即可看到所有可用 Skill 及其 description
- Skill 状态变化时通过 `_onSkillsChanged` 回调自动重建工具声明
- 无 Skill 时不注册工具，避免空参数列表混淆 LLM

### 2. Skill 注入引导词（skillPreamble）
- `SystemConfig` 新增 `skillPreamble` 配置项，支持 `{{SKILL}}` 占位符
- 内置默认引导词格式：`===== ACTIVE SKILLS =====` / `===== SKILL: name =====` / `===== END: name =====`
- 用户可在 `system.yaml` 中自定义引导词模板，也可设为空字符串恢复旧行为

### 3. Telegram inline keyboard 交互
- `/model`、`/session`、`/mode`、`/skill` 无参数时回复 inline keyboard 按钮列表
- 用户点击按钮直接执行切换，bot 编辑原消息显示结果
- 新增 `sendMessageWithKeyboard`、`onCallbackQuery`、`answerCallbackQuery` 方法
- 新增 `handleCallbackQuery` 处理 callback_data

### 4. 配置与权限同步
- `tools.yaml` / `embedded-defaults.ts` 中 `manage_skills` → `toggle_skills`
- `bootstrap.ts` / `runtime.ts` 传递 `skillPreamble` 配置
- 热重载时自动更新 Skill 列表和引导词
