### PR TITLE
feat(pairing): 新增平台层对码访问控制系统，首期接入 Telegram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/platforms/web/web-ui/node_modules/
 *.log
 logs/
 limcode/
+.limcode/
 
 .env
 

--- a/data/configs.example/platform.yaml
+++ b/data/configs.example/platform.yaml
@@ -6,6 +6,16 @@
 #   type: [console, web]     # 多平台同时启动
 type: console
 
+# 对码系统配置（可选，平台层访问控制）
+# dmPolicy: 
+#   pairing   = 需对码验证（默认，通过 /invite 生成码）
+#   allowlist = 仅配置的 allowFrom 成员可用
+#   open      = 任何人均可私聊
+pairing:
+  dmPolicy: pairing
+  # admin: "telegram:123456"       # 可直接指定管理员（跳过首次对码）
+  # allowFrom: ["telegram:123"]    # 预设白名单
+
 discord:
   token: your-discord-bot-token
 

--- a/src/config/platform.ts
+++ b/src/config/platform.ts
@@ -40,14 +40,37 @@ function parseTypes(raw: unknown): string[] {
 
 export function parsePlatformConfig(raw: any = {}): PlatformConfig {
   const source = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
+
+  // 全局对码配置默认值
+  const globalPairing = {
+    dmPolicy: source.pairing?.dmPolicy ?? 'pairing',
+    admin: source.pairing?.admin,
+    allowFrom: source.pairing?.allowFrom,
+  };
+
+  // 辅助函数：合并分平台覆盖
+  const parsePairingOverride = (platformPairing: any) => {
+    if (!platformPairing) return globalPairing;
+    return {
+      dmPolicy: platformPairing.dmPolicy ?? globalPairing.dmPolicy,
+      admin: platformPairing.admin ?? globalPairing.admin,
+      allowFrom: platformPairing.allowFrom ?? globalPairing.allowFrom,
+    };
+  };
+
   return {
     ...source,
     types: parseTypes(source.type),
-    discord: { token: source.discord?.token ?? '' },
+    pairing: globalPairing,
+    discord: {
+      token: source.discord?.token ?? '',
+      pairing: parsePairingOverride(source.discord?.pairing),
+    },
     telegram: {
       token: source.telegram?.token ?? '',
       showToolStatus: source.telegram?.showToolStatus !== false,
       groupMentionRequired: source.telegram?.groupMentionRequired !== false,
+      pairing: parsePairingOverride(source.telegram?.pairing),
     },
     web: {
       port: source.web?.port ?? 8192,
@@ -59,6 +82,7 @@ export function parsePlatformConfig(raw: any = {}): PlatformConfig {
       botId: source.wxwork?.botId ?? '',
       secret: source.wxwork?.secret ?? '',
       showToolStatus: source.wxwork?.showToolStatus !== false,
+      pairing: parsePairingOverride(source.wxwork?.pairing),
     },
     lark: {
       appId: source.lark?.appId ?? '',
@@ -66,6 +90,7 @@ export function parsePlatformConfig(raw: any = {}): PlatformConfig {
       verificationToken: source.lark?.verificationToken,
       encryptKey: source.lark?.encryptKey,
       showToolStatus: source.lark?.showToolStatus !== false,
+      pairing: parsePairingOverride(source.lark?.pairing),
     },
     qq: {
       wsUrl: source.qq?.wsUrl ?? 'ws://127.0.0.1:3001',
@@ -73,6 +98,7 @@ export function parsePlatformConfig(raw: any = {}): PlatformConfig {
       selfId: source.qq?.selfId ?? '',
       groupMode: source.qq?.groupMode ?? 'at',
       showToolStatus: source.qq?.showToolStatus !== false,
+      pairing: parsePairingOverride(source.qq?.pairing),
     },
   } as PlatformConfig;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { OCRConfig } from './ocr';
+import type { PairingConfig } from '../platforms/pairing/types';
 
 export interface LLMConfig {
   provider: string;
@@ -45,7 +46,13 @@ export interface LLMRegistryConfig {
 export interface PlatformConfig {
   /** 启动的平台类型列表（兼容单字符串和数组写法；支持插件平台注册的自定义平台） */
   types: string[];
-  discord: { token: string };
+  /** 全局对码配置 */
+  pairing?: PairingConfig;
+  discord: {
+    token: string;
+    /** 对码配置（已与全局合并，由 parsePlatformConfig 填充默认值） */
+    pairing?: PairingConfig;
+  };
   telegram: {
     token: string;
     /**
@@ -55,6 +62,8 @@ export interface PlatformConfig {
     showToolStatus?: boolean;
     /** 群聊中是否必须显式 @ 机器人后才响应，默认 true。 */
     groupMentionRequired?: boolean;
+    /** 对码配置（已与全局合并，由 parsePlatformConfig 填充默认值） */
+    pairing?: PairingConfig;
   };
   web: {
     port: number;
@@ -69,6 +78,8 @@ export interface PlatformConfig {
     secret: string;
     /** 是否在流式回复中展示工具执行状态（默认 true） */
     showToolStatus?: boolean;
+    /** 对码配置（已与全局合并，由 parsePlatformConfig 填充默认值） */
+    pairing?: PairingConfig;
   };
   lark: {
     /**
@@ -84,6 +95,8 @@ export interface PlatformConfig {
     encryptKey?: string;
     /** 是否在流式回复中展示工具执行状态（默认 true）。 */
     showToolStatus?: boolean;
+    /** 对码配置（已与全局合并，由 parsePlatformConfig 填充默认值） */
+    pairing?: PairingConfig;
   };
   qq: {
     /** NapCat OneBot v11 正向 WebSocket 地址 */
@@ -96,6 +109,8 @@ export interface PlatformConfig {
     groupMode?: 'at' | 'all' | 'off';
     /** 是否在回复中展示工具执行状态（默认 true） */
     showToolStatus?: boolean;
+    /** 对码配置（已与全局合并，由 parsePlatformConfig 填充默认值） */
+    pairing?: PairingConfig;
   };
   [key: string]: unknown;
 }

--- a/src/platforms/discord/index.ts
+++ b/src/platforms/discord/index.ts
@@ -100,6 +100,9 @@ export class DiscordPlatform extends PlatformAdapter {
     if (msg.author.bot) return;
     if (!msg.content) return;
 
+    // TODO: 对码门禁 — 后续接入 PairingGuard，当前未实现。
+    // 设计文档：.limcode/design/对码系统设计.md
+
     const isDM = !msg.guild;
     const isMentioned = msg.mentions.has(this.client.user!);
 

--- a/src/platforms/lark/index.ts
+++ b/src/platforms/lark/index.ts
@@ -379,6 +379,9 @@ export class LarkPlatform extends PlatformAdapter {
     const cs = this.getChatState(parsed.session);
     cs.lastInboundMessageId = parsed.messageId;
 
+    // TODO: 对码门禁 — 后续接入 PairingGuard，当前未实现。
+    // 设计文档：.limcode/design/对码系统设计.md
+
     // 命令处理
     if (parsed.text.startsWith('/')) {
       const handled = await this.handleCommand(parsed.text, cs);

--- a/src/platforms/pairing/code-gen.ts
+++ b/src/platforms/pairing/code-gen.ts
@@ -1,0 +1,17 @@
+/**
+ * 对码生成器。
+ *
+ * 生成 6 位大写字母 + 数字组成的对码，排除易混淆字符（0/O、1/I、L）。
+ * 对码用于平台层用户身份验证，与 Backend 无关。
+ */
+
+// 排除 0, O, 1, I, L
+const CHARSET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+export function generatePairingCode(length = 6): string {
+  let code = '';
+  for (let i = 0; i < length; i++) {
+    code += CHARSET[Math.floor(Math.random() * CHARSET.length)];
+  }
+  return code;
+}

--- a/src/platforms/pairing/guard.ts
+++ b/src/platforms/pairing/guard.ts
@@ -1,0 +1,203 @@
+/**
+ * 对码系统门禁逻辑。
+ *
+ * 核心类 PairingGuard，负责用户请求的权限检查。
+ */
+
+import { PairingConfig, PairingCheckResult, PendingPairing, AllowedUser, PairingAdmin } from './types';
+import { PairingStore } from './store';
+import { generatePairingCode } from './code-gen';
+
+export class PairingGuard {
+  constructor(
+    private platform: string,
+    private config: PairingConfig,
+    private store: PairingStore
+  ) {}
+
+  /**
+   * 检查用户消息是否有权进入 Backend。
+   * @param userId 平台端的用户 ID
+   * @param messageText 消息内容（用于匹配对码）
+   * @param userName 可选的用户名
+   */
+  check(userId: string, messageText: string, userName?: string): PairingCheckResult {
+    // 1. 如果 dmPolicy === 'open'，直接放行
+    if (this.config.dmPolicy === 'open') {
+      return { allowed: true };
+    }
+
+    const platformUserId = `${this.platform}:${userId}`;
+
+    // 2. 检查用户是否在配置的 allowFrom 中
+    if (this.config.allowFrom && this.config.allowFrom.includes(platformUserId)) {
+      return { allowed: true };
+    }
+
+    // 3. 检查用户是否在配置中直接指定为 admin
+    if (this.config.admin === platformUserId) {
+      return { allowed: true };
+    }
+
+    // 4. 检查用户是否在 store 的白名单中
+    const allowlist = this.store.loadAllowlist();
+    if (allowlist.some(u => u.platform === this.platform && u.userId === userId)) {
+      return { allowed: true };
+    }
+
+    // 5. 检查是否为当前管理员
+    const admin = this.store.loadAdmin();
+    if (admin && admin.platform === this.platform && admin.userId === userId) {
+      return { allowed: true };
+    }
+
+    // 每次 check 调用时清理过期的 pending 对码
+    this.cleanExpiredPending();
+
+    // 6. 如果 dmPolicy === 'allowlist'，不在名单就拒绝
+    if (this.config.dmPolicy === 'allowlist') {
+      return {
+        allowed: false,
+        reason: 'needs-pairing',
+        replyText: '需要对码验证，请联系管理员。',
+      };
+    }
+
+    // 7. 如果 dmPolicy === 'pairing'：
+    const inputCode = messageText.trim().toUpperCase();
+    const pending = this.store.loadPending();
+    const matchIndex = pending.findIndex(p => p.code.toUpperCase() === inputCode);
+
+    if (matchIndex !== -1) {
+      const p = pending[matchIndex];
+
+      // 匹配到 bootstrap 对码（platform='*'）
+      if (p.platform === '*' && p.userId === '*') {
+        // 设为管理员
+        const newAdmin: PairingAdmin = {
+          platform: this.platform,
+          userId,
+          userName,
+          setAt: Date.now(),
+          source: 'first-pairing',
+        };
+        this.store.saveAdmin(newAdmin);
+        // 加白名单
+        this.addUserToAllowlist(userId, userName);
+        // 移除该 bootstrap 对码
+        pending.splice(matchIndex, 1);
+        this.store.savePending(pending);
+
+        return {
+          allowed: false,
+          reason: 'bootstrap-success',
+          replyText: `对码成功！你已成为管理员 (ID: ${userId})。`,
+        };
+      }
+
+      // 匹配到普通邀请对码
+      this.addUserToAllowlist(userId, userName);
+      // 移除对码（一次性）
+      pending.splice(matchIndex, 1);
+      this.store.savePending(pending);
+
+      return {
+        allowed: false,
+        reason: 'pairing-success',
+        replyText: '对码成功！你已获得使用权限。',
+      };
+    }
+
+    // 都不匹配
+    return {
+      allowed: false,
+      reason: 'needs-pairing',
+      replyText: '需要对码验证，请联系管理员获取对码。',
+    };
+  }
+
+  /** 检查用户是否为管理员 */
+  isAdmin(userId: string): boolean {
+    const platformUserId = `${this.platform}:${userId}`;
+    if (this.config.admin === platformUserId) return true;
+    const admin = this.store.loadAdmin();
+    return !!(admin && admin.platform === this.platform && admin.userId === userId);
+  }
+
+  /** 生成邀请对码（1 小时过期） */
+  generateInviteCode(): string {
+    const code = generatePairingCode();
+    const pending = this.store.loadPending();
+
+    // 每个平台最多 5 个 pending
+    const platformPending = pending.filter(p => p.platform !== '*');
+    if (platformPending.length >= 5) {
+      const oldestIndex = pending.findIndex(p => p.platform !== '*');
+      if (oldestIndex !== -1) pending.splice(oldestIndex, 1);
+    }
+
+    pending.push({
+      code,
+      platform: this.platform,
+      userId: '',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 3600000,
+    });
+    this.store.savePending(pending);
+    return code;
+  }
+
+  listPending(): PendingPairing[] {
+    return this.store.loadPending();
+  }
+
+  listUsers(): AllowedUser[] {
+    return this.store.loadAllowlist();
+  }
+
+  /** 让渡管理员身份 */
+  transferAdmin(targetPlatform: string, targetUserId: string): boolean {
+    const newAdmin: PairingAdmin = {
+      platform: targetPlatform,
+      userId: targetUserId,
+      setAt: Date.now(),
+      source: 'transfer',
+    };
+    this.store.saveAdmin(newAdmin);
+    return true;
+  }
+
+  /** 移除用户白名单 */
+  removeUser(targetPlatform: string, targetUserId: string): boolean {
+    let allowlist = this.store.loadAllowlist();
+    const initialLen = allowlist.length;
+    allowlist = allowlist.filter(u => !(u.platform === targetPlatform && u.userId === targetUserId));
+    if (allowlist.length !== initialLen) {
+      this.store.saveAllowlist(allowlist);
+      return true;
+    }
+    return false;
+  }
+
+  private addUserToAllowlist(userId: string, userName?: string) {
+    const allowlist = this.store.loadAllowlist();
+    if (!allowlist.some(u => u.platform === this.platform && u.userId === userId)) {
+      allowlist.push({
+        platform: this.platform,
+        userId,
+        userName,
+        pairedAt: Date.now(),
+      });
+      this.store.saveAllowlist(allowlist);
+    }
+  }
+
+  private cleanExpiredPending() {
+    const pending = this.store.loadPending();
+    const now = Date.now();
+    const filtered = pending.filter(p => p.expiresAt > now);
+    if (filtered.length !== pending.length) {
+      this.store.savePending(filtered);
+    }
+  }
+}

--- a/src/platforms/pairing/index.ts
+++ b/src/platforms/pairing/index.ts
@@ -1,0 +1,10 @@
+/**
+ * 对码系统模块入口。
+ *
+ * 统一导出该模块的公开 API。
+ */
+
+export { PairingGuard } from './guard';
+export { PairingStore } from './store';
+export { generatePairingCode } from './code-gen';
+export type { PairingConfig, PairingCheckResult, PendingPairing, AllowedUser, PairingAdmin } from './types';

--- a/src/platforms/pairing/store.ts
+++ b/src/platforms/pairing/store.ts
@@ -1,0 +1,112 @@
+/**
+ * 对码系统状态持久化存储。
+ *
+ * 存储在 ~/.iris/credentials/ 下的 JSON 文件中。
+ * 支持多 Agent 场景通过构造函数传入 dataDir。
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { dataDir } from '../../paths';
+import { createLogger } from '../../logger';
+import { PendingPairing, AllowedUser, PairingAdmin } from './types';
+import { generatePairingCode } from './code-gen';
+
+const logger = createLogger('PairingStore');
+
+/** 永不过期的时间戳（用于 bootstrap） */
+const NEVER_EXPIRE = 253402272000000; // 9999-12-31
+
+export class PairingStore {
+  private credentialsDir: string;
+
+  constructor(customDataDir?: string) {
+    this.credentialsDir = path.join(customDataDir || dataDir, 'credentials');
+    try {
+      if (!fs.existsSync(this.credentialsDir)) {
+        fs.mkdirSync(this.credentialsDir, { recursive: true });
+      }
+    } catch (e) {
+      logger.error('Failed to create credentials directory:', e);
+    }
+  }
+
+  private getPath(filename: string): string {
+    return path.join(this.credentialsDir, filename);
+  }
+
+  private loadJSON<T>(filename: string, defaultValue: T): T {
+    const filePath = this.getPath(filename);
+    if (!fs.existsSync(filePath)) return defaultValue;
+    try {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      if (!content.trim()) return defaultValue;
+      return JSON.parse(content) as T;
+    } catch (e) {
+      logger.error(`Failed to load ${filename}:`, e);
+      return defaultValue;
+    }
+  }
+
+  private saveJSON<T>(filename: string, data: T): void {
+    const filePath = this.getPath(filename);
+    const tempPath = `${filePath}.tmp`;
+    try {
+      const content = JSON.stringify(data, null, 2);
+      fs.writeFileSync(tempPath, content, 'utf-8');
+      fs.renameSync(tempPath, filePath);
+    } catch (e) {
+      logger.error(`Failed to save ${filename}:`, e);
+      if (fs.existsSync(tempPath)) {
+        try { fs.unlinkSync(tempPath); } catch {}
+      }
+    }
+  }
+
+  loadPending(): PendingPairing[] {
+    return this.loadJSON<PendingPairing[]>('pairing-pending.json', []);
+  }
+
+  savePending(pending: PendingPairing[]): void {
+    this.saveJSON('pairing-pending.json', pending);
+  }
+
+  loadAllowlist(): AllowedUser[] {
+    return this.loadJSON<AllowedUser[]>('pairing-allowlist.json', []);
+  }
+
+  saveAllowlist(allowlist: AllowedUser[]): void {
+    this.saveJSON('pairing-allowlist.json', allowlist);
+  }
+
+  loadAdmin(): PairingAdmin | null {
+    return this.loadJSON<PairingAdmin | null>('pairing-admin.json', null);
+  }
+
+  saveAdmin(admin: PairingAdmin | null): void {
+    this.saveJSON('pairing-admin.json', admin);
+  }
+
+  /** 是否需要首次对码（无管理员） */
+  needsBootstrap(): boolean {
+    return this.loadAdmin() === null;
+  }
+
+  /** 获取或创建启动对码 */
+  getOrCreateBootstrapCode(): string {
+    const pending = this.loadPending();
+    const bootstrap = pending.find(p => p.platform === '*' && p.userId === '*');
+    if (bootstrap) return bootstrap.code;
+
+    const newCode = generatePairingCode();
+    pending.push({
+      code: newCode,
+      platform: '*',
+      userId: '*',
+      createdAt: Date.now(),
+      expiresAt: NEVER_EXPIRE,
+    });
+    this.savePending(pending);
+    return newCode;
+  }
+}

--- a/src/platforms/pairing/types.ts
+++ b/src/platforms/pairing/types.ts
@@ -1,0 +1,58 @@
+/**
+ * 对码系统类型定义。
+ *
+ * 对码系统是纯平台层的访问控制机制，与 Backend 完全无关。
+ * 未通过对码的用户消息不会进入 backend.chat()。
+ */
+
+/** 对码策略配置 */
+export interface PairingConfig {
+  /** DM 策略：pairing = 需要对码（默认）| allowlist = 仅白名单 | open = 任何人 */
+  dmPolicy: 'pairing' | 'allowlist' | 'open';
+  /** 管理员 ID，格式 <platform>:<userId>（可选，直接指定则跳过首次对码） */
+  admin?: string;
+  /** 预设白名单，格式 <platform>:<userId>（可选） */
+  allowFrom?: string[];
+}
+
+/** 待审批对码请求 */
+export interface PendingPairing {
+  code: string;
+  platform: string;
+  userId: string;
+  userName?: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+/** 已放行用户 */
+export interface AllowedUser {
+  platform: string;
+  userId: string;
+  userName?: string;
+  pairedAt: number;
+}
+
+/** 管理员信息 */
+export interface PairingAdmin {
+  platform: string;
+  userId: string;
+  userName?: string;
+  setAt: number;
+  source: 'first-pairing' | 'config' | 'transfer';
+}
+
+/** PairingGuard.check() 的返回结果 */
+export interface PairingCheckResult {
+  /** 是否放行该消息进入 Backend */
+  allowed: boolean;
+  /**
+   * allowed=false 时的具体原因：
+   *   - needs-pairing: 用户未对码，需要联系管理员
+   *   - bootstrap-success: 首次启动对码成功，该用户已成为管理员
+   *   - pairing-success: 普通对码成功
+   */
+  reason?: 'needs-pairing' | 'bootstrap-success' | 'pairing-success';
+  /** 需要回复给用户的文本（allowed=false 或对码成功时） */
+  replyText?: string;
+}

--- a/src/platforms/qq/index.ts
+++ b/src/platforms/qq/index.ts
@@ -733,6 +733,9 @@ export class QQPlatform extends PlatformAdapter {
       return;
     }
 
+    // TODO: 对码门禁 — 后续接入 PairingGuard，当前未实现。
+    // 设计文档：.limcode/design/对码系统设计.md
+
     const ck = this.chatKey(messageType, senderId, groupId);
     const target: MessageTarget = messageType === 'group'
       ? { groupId }

--- a/src/platforms/registry.ts
+++ b/src/platforms/registry.ts
@@ -80,6 +80,7 @@ export function createDefaultPlatformRegistry(): PlatformRegistry {
       token: config.platform.telegram.token,
       showToolStatus: config.platform.telegram.showToolStatus,
       groupMentionRequired: config.platform.telegram.groupMentionRequired,
+      pairing: config.platform.telegram.pairing,
     });
   });
 

--- a/src/platforms/telegram/commands.ts
+++ b/src/platforms/telegram/commands.ts
@@ -23,6 +23,10 @@ export const TELEGRAM_BOT_COMMANDS = [
   { command: 'redo', description: '恢复撤销的对话' },
   { command: 'skill', description: '查看 Skill 列表或详情' },
   { command: 'mode', description: '查看或切换 Mode（提示词模式）' },
+  { command: 'invite', description: '生成邀请对码（管理员）' },
+  { command: 'users', description: '查看白名单用户（管理员）' },
+  { command: 'kick', description: '移除白名单用户（管理员）' },
+  { command: 'transfer', description: '让渡管理员身份（管理员）' },
   { command: 'help', description: '显示帮助' },
 ];
 

--- a/src/platforms/telegram/index.ts
+++ b/src/platforms/telegram/index.ts
@@ -12,6 +12,8 @@ import { PlatformAdapter } from '../base';
 import { Backend } from '../../core/backend';
 import type { ImageInput, DocumentInput } from '../../core/backend';
 import { createLogger } from '../../logger';
+import { PairingGuard, PairingStore } from '../pairing';
+import { dataDir } from '../../paths';
 import { TelegramClient } from './client';
 import { TelegramCommandRouter } from './commands';
 import { TelegramMediaService } from './media';
@@ -82,6 +84,8 @@ export class TelegramPlatform extends PlatformAdapter {
   private readonly commandRouter: TelegramCommandRouter;
   private readonly mediaService: TelegramMediaService;
   private readonly showToolStatus: boolean;
+  private readonly pairingStore: PairingStore | null;
+  private readonly pairingGuard: PairingGuard | null;
 
   private readonly chatStates = new Map<string, TelegramChatState>();
   /** chatKey → sessionId 映射，/new 时更新 */
@@ -99,6 +103,15 @@ export class TelegramPlatform extends PlatformAdapter {
     this.commandRouter = new TelegramCommandRouter();
     this.mediaService = new TelegramMediaService();
     this.showToolStatus = config.showToolStatus !== false;
+
+    // 对码门禁初始化（仅在配置了 pairing 且 dmPolicy !== 'open' 时创建）
+    if (config.pairing && config.pairing.dmPolicy !== 'open') {
+      this.pairingStore = new PairingStore();
+      this.pairingGuard = new PairingGuard('telegram', config.pairing, this.pairingStore);
+    } else {
+      this.pairingStore = null;
+      this.pairingGuard = null;
+    }
   }
 
   async start(): Promise<void> {
@@ -107,6 +120,18 @@ export class TelegramPlatform extends PlatformAdapter {
     this.client.onCallbackQuery((ctx) => this.handleCallbackQuery(ctx));
     await this.client.start();
     logger.info('Telegram 平台已启动');
+
+    // 启动对码输出
+    if (this.pairingGuard && this.pairingStore?.needsBootstrap()) {
+      const code = this.pairingStore.getOrCreateBootstrapCode();
+      logger.info('');
+      logger.info('╔════════════════════════════════════════════════════════╗');
+      logger.info('║  首次使用，请在 Telegram 发送以下对码完成管理员绑定：    ║');
+      logger.info(`║  对码：${code}                                          ║`);
+      logger.info('║  第一个完成对码的用户将成为管理员。                      ║');
+      logger.info('╚════════════════════════════════════════════════════════╝');
+      logger.info('');
+    }
   }
 
   async stop(): Promise<void> {
@@ -444,6 +469,29 @@ export class TelegramPlatform extends PlatformAdapter {
         return;
       }
 
+      // ---- 对码门禁 ----
+      // 目的：在消息进入 Backend 之前，检查用户是否有权使用 Bot。
+      // 仅对私聊生效；群聊在上方 mention 检查中已处理。
+      // 对码系统与 Backend 完全无关，纯平台层访问控制。
+      if (this.pairingGuard && parsed.session.scope === 'dm') {
+        const senderId = String(ctx.from?.id ?? '');
+        const senderName = ctx.from?.username || ctx.from?.first_name || '';
+        const result = this.pairingGuard.check(senderId, parsed.text, senderName);
+        if (!result.allowed) {
+          if (result.replyText) {
+            await this.client.sendText(parsed.session, result.replyText);
+          }
+          return;
+        }
+        // 对码成功消息也需要回复但不进入 Backend
+        if (result.reason === 'bootstrap-success' || result.reason === 'pairing-success') {
+          if (result.replyText) {
+            await this.client.sendText(parsed.session, result.replyText);
+          }
+          return;
+        }
+      }
+
       const cs = this.getChatState(parsed.session);
       cs.lastInboundMessageId = parsed.messageId;
 
@@ -753,6 +801,63 @@ export class TelegramPlatform extends PlatformAdapter {
             keyboard,
           );
         }
+        return true;
+      }
+
+      case 'invite': {
+        const userId = String(cs.target.chatId);
+        if (!this.pairingGuard?.isAdmin(userId)) {
+          await reply('❌ 仅管理员可使用此命令。');
+          return true;
+        }
+        const code = this.pairingGuard.generateInviteCode();
+        await reply(`🎫 对码已生成：\`${code}\`（1 小时内有效）`);
+        return true;
+      }
+
+      case 'users': {
+        const userId = String(cs.target.chatId);
+        if (!this.pairingGuard?.isAdmin(userId)) {
+          await reply('❌ 仅管理员可使用此命令。');
+          return true;
+        }
+        const users = this.pairingGuard.listUsers();
+        if (users.length === 0) {
+          await reply('ℹ️ 当前白名单为空。');
+        } else {
+          const list = users.map(u => `- ${u.userName || '未知'}(${u.platform}:${u.userId}) 于 ${new Date(u.pairedAt).toLocaleString()} 加入`).join('\n');
+          await reply(`👥 白名单用户：\n${list}`);
+        }
+        return true;
+      }
+
+      case 'kick': {
+        const userId = String(cs.target.chatId);
+        if (!this.pairingGuard?.isAdmin(userId)) {
+          await reply('❌ 仅管理员可使用此命令。');
+          return true;
+        }
+        if (!cmd.args) {
+          await reply('❌ 请提供要移除的用户 ID。格式：/kick <userId>');
+          return true;
+        }
+        const ok = this.pairingGuard.removeUser('telegram', cmd.args);
+        await reply(ok ? `✅ 用户 ${cmd.args} 已从白名单移除。` : `❌ 未找到用户 ${cmd.args}。`);
+        return true;
+      }
+
+      case 'transfer': {
+        const userId = String(cs.target.chatId);
+        if (!this.pairingGuard?.isAdmin(userId)) {
+          await reply('❌ 仅管理员可使用此命令。');
+          return true;
+        }
+        if (!cmd.args) {
+          await reply('❌ 请提供新的管理员 ID。格式：/transfer <userId>');
+          return true;
+        }
+        this.pairingGuard.transferAdmin('telegram', cmd.args);
+        await reply(`✅ 管理员身份已让渡给用户 ${cmd.args}。`);
         return true;
       }
 

--- a/src/platforms/telegram/types.ts
+++ b/src/platforms/telegram/types.ts
@@ -16,6 +16,8 @@ export interface TelegramConfig {
   showToolStatus?: boolean;
   /** 群聊中是否要求显式 @ 机器人后才响应，默认 true。 */
   groupMentionRequired?: boolean;
+  /** 对码配置（从全局配置与分平台覆盖合并后传入） */
+  pairing?: import('../pairing/types').PairingConfig;
 }
 
 export interface TelegramPhotoRef {

--- a/src/platforms/wxwork/index.ts
+++ b/src/platforms/wxwork/index.ts
@@ -752,6 +752,9 @@ export class WXWorkPlatform extends PlatformAdapter {
 
     const ck = this.chatKey(chatType, chatId, senderId);
 
+    // TODO: 对码门禁 — 后续接入 PairingGuard，当前未实现。
+    // 设计文档：.limcode/design/对码系统设计.md
+
     logger.info(`[${ck}] from=${senderId}: text="${parsed.text.slice(0, 50)}" images=${parsed.imageUrls.length}`);
 
     // 指令处理（任何时候都能用，不受 busy 影响）

--- a/tests/pairing.test.ts
+++ b/tests/pairing.test.ts
@@ -1,0 +1,179 @@
+/**
+ * 对码系统单元测试。
+ *
+ * 测试对码生成器、存储和门禁逻辑。
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { generatePairingCode } from '../src/platforms/pairing/code-gen';
+import { PairingStore } from '../src/platforms/pairing/store';
+import { PairingGuard } from '../src/platforms/pairing/guard';
+import { PairingConfig } from '../src/platforms/pairing/types';
+
+describe('Pairing System', () => {
+  let testDataDir: string;
+
+  beforeEach(() => {
+    testDataDir = path.join(os.tmpdir(), `iris-test-${Date.now()}`);
+    if (!fs.existsSync(testDataDir)) {
+      fs.mkdirSync(testDataDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testDataDir)) {
+      fs.rmSync(testDataDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('generatePairingCode', () => {
+    it('should generate a 6-character code', () => {
+      const code = generatePairingCode();
+      expect(code).toHaveLength(6);
+    });
+
+    it('should not contain confusing characters', () => {
+      const confusing = ['0', 'O', '1', 'I', 'L'];
+      for (let i = 0; i < 100; i++) {
+        const code = generatePairingCode();
+        for (const char of confusing) {
+          expect(code).not.toContain(char);
+        }
+      }
+    });
+  });
+
+  describe('PairingStore', () => {
+    it('should initialize and create credentials directory', () => {
+      const store = new PairingStore(testDataDir);
+      expect(fs.existsSync(path.join(testDataDir, 'credentials'))).toBe(true);
+    });
+
+    it('should load and save pending pairings', () => {
+      const store = new PairingStore(testDataDir);
+      const pending = [{
+        code: 'TEST12',
+        platform: 'test',
+        userId: 'user1',
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 3600000,
+      }];
+      store.savePending(pending);
+      const loaded = store.loadPending();
+      expect(loaded).toEqual(pending);
+    });
+
+    it('should load and save admin', () => {
+      const store = new PairingStore(testDataDir);
+      const admin = {
+        platform: 'test',
+        userId: 'admin1',
+        setAt: Date.now(),
+        source: 'first-pairing' as const,
+      };
+      store.saveAdmin(admin);
+      const loaded = store.loadAdmin();
+      expect(loaded).toEqual(admin);
+    });
+
+    it('should generate bootstrap code when needed', () => {
+      const store = new PairingStore(testDataDir);
+      expect(store.needsBootstrap()).toBe(true);
+      const code = store.getOrCreateBootstrapCode();
+      expect(code).toHaveLength(6);
+      expect(store.loadPending()).toHaveLength(1);
+      expect(store.loadPending()[0].platform).toBe('*');
+    });
+  });
+
+  describe('PairingGuard', () => {
+    let store: PairingStore;
+    const defaultConfig: PairingConfig = {
+      dmPolicy: 'pairing',
+    };
+
+    beforeEach(() => {
+      store = new PairingStore(testDataDir);
+    });
+
+    it('should allow everyone if dmPolicy is open', () => {
+      const guard = new PairingGuard('test', { dmPolicy: 'open' }, store);
+      const result = guard.check('user1', 'Hello');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should block un-paired user if dmPolicy is pairing', () => {
+      const guard = new PairingGuard('test', { dmPolicy: 'pairing' }, store);
+      const result = guard.check('user1', 'Hello');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('needs-pairing');
+    });
+
+    it('should allow paired user from allowlist', () => {
+      store.saveAllowlist([{
+        platform: 'test',
+        userId: 'user1',
+        pairedAt: Date.now(),
+      }]);
+      const guard = new PairingGuard('test', { dmPolicy: 'pairing' }, store);
+      const result = guard.check('user1', 'Hello');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should handle bootstrap pairing', () => {
+      const guard = new PairingGuard('test', { dmPolicy: 'pairing' }, store);
+      const code = store.getOrCreateBootstrapCode();
+      
+      const result = guard.check('user1', code, 'User One');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('bootstrap-success');
+      expect(guard.isAdmin('user1')).toBe(true);
+      
+      // Subsequent messages should be allowed
+      const result2 = guard.check('user1', 'Normal message');
+      expect(result2.allowed).toBe(true);
+    });
+
+    it('should handle invite pairing', () => {
+      const guard = new PairingGuard('test', { dmPolicy: 'pairing' }, store);
+      // Make user1 an admin first
+      store.saveAdmin({
+          platform: 'test',
+          userId: 'admin1',
+          setAt: Date.now(),
+          source: 'config',
+      });
+
+      const inviteCode = guard.generateInviteCode();
+      const result = guard.check('user2', inviteCode, 'User Two');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('pairing-success');
+      
+      const result2 = guard.check('user2', 'Hello');
+      expect(result2.allowed).toBe(true);
+    });
+
+    it('should block user not in allowFrom if policy is allowlist', () => {
+        const guard = new PairingGuard('test', { dmPolicy: 'allowlist', allowFrom: ['test:user1'] }, store);
+        expect(guard.check('user1', 'Hi').allowed).toBe(true);
+        expect(guard.check('user2', 'Hi').allowed).toBe(false);
+    });
+
+    it('should respect expired codes', async () => {
+        const guard = new PairingGuard('test', { dmPolicy: 'pairing' }, store);
+        const code = guard.generateInviteCode();
+        
+        // Mock expiration
+        const pending = store.loadPending();
+        pending[0].expiresAt = Date.now() - 1000;
+        store.savePending(pending);
+        
+        const result = guard.check('user2', code);
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toBe('needs-pairing');
+    });
+  });
+});


### PR DESCRIPTION
## 改动

- 新增 `src/platforms/pairing/` 对码核心模块（types / code-gen / store / guard）
- 配置层新增全局 `pairing` 字段及各平台分层覆盖支持（`src/config/types.ts`、`src/config/platform.ts`）
- Telegram 平台接入对码门禁：私聊需对码，群聊跳过；新增管理员命令 `/invite` `/users` `/kick` `/transfer`；首次启动在控制台输出 bootstrap 对码
- Discord / Lark / WXWork / QQ 平台在 `handleMessage` 入口预留 TODO 注释，待后续接入
- 更新 `data/configs.example/platform.yaml` 补充对码配置示例
- 新增 `tests/pairing.test.ts`，13 个测试用例覆盖核心路径
- `.gitignore` 新增 `.limcode/` 忽略规则

## 原因

当前所有平台适配器收到消息后直接转发给 Backend，任何知道 Bot 用户名的人均可直接使用 Agent。对码系统在平台层做访问控制，与 Backend 完全解耦。

## 设计要点

- 对码系统不修改 Backend 任何逻辑，纯平台层门禁
- 默认策略 `dmPolicy: pairing`，console / web 平台硬编码豁免
- 首位完成 bootstrap 对码的用户自动成为管理员
- 管理员可通过平台内命令邀请、移除用户及让渡管理员身份
- 配置支持全局默认，各平台可独立覆盖
