### PR TITLE
feat(claude): add Anthropic Prompt Caching support

### DIFF
--- a/data/configs.example/llm.yaml
+++ b/data/configs.example/llm.yaml
@@ -73,6 +73,19 @@ models:
 #     apiKey: your-api-key-here
 #     model: claude-sonnet-4-6
 #     baseUrl: https://api.anthropic.com/v1
+#     # Enable Anthropic Prompt Caching (manual cache breakpoints).
+#     # Injects cache_control: { type: "ephemeral" } at key positions:
+#     #   1. tools    — last tool definition
+#     #   2. system   — system instruction (converted to content-block array)
+#     #   3. messages — last content block of the last user message
+#     # Uses at most 3 breakpoints (Anthropic allows up to 4).
+#     # Cached reads cost only 10% of base input token price.
+#     # promptCaching: true
+#     # Enable Anthropic automatic prompt caching.
+#     # Adds top-level cache_control to the request body;
+#     # the server decides which prefix to cache automatically.
+#     # Can be used independently or together with promptCaching.
+#     # autoCaching: true
 # Gemini 示例：
 # models:
 #   gemini_flash:

--- a/src/config/llm.ts
+++ b/src/config/llm.ts
@@ -48,6 +48,8 @@ export function parseSingleLLMConfig(raw: any = {}): LLMConfig {
       : undefined,
     headers: source.headers && typeof source.headers === 'object' && !Array.isArray(source.headers) ? source.headers : undefined,
     requestBody: source.requestBody && typeof source.requestBody === 'object' && !Array.isArray(source.requestBody) ? source.requestBody : undefined,
+    promptCaching: source.promptCaching === true ? true : undefined,
+    autoCaching: source.autoCaching === true ? true : undefined,
   };
 }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -25,6 +25,36 @@ export interface LLMConfig {
   headers?: Record<string, string>;
   /** 自定义请求体，会深合并到 provider 编码后的最终请求体，支持嵌套参数 */
   requestBody?: Record<string, unknown>;
+  /**
+   * [Claude only] Enable Anthropic Prompt Caching (manual cache breakpoints).
+   *
+   * When enabled, cache_control: { type: "ephemeral" } markers are injected at
+   * key positions in the request body following Anthropic's cache prefix hierarchy:
+   *   1. tools  — last tool definition
+   *   2. system — system instruction (converted to content-block array)
+   *   3. messages — last content block of the last user message
+   *
+   * At most 3 breakpoints are used (Anthropic allows up to 4).
+   * Cached reads cost only 10% of base input token price.
+   *
+   * Only takes effect when provider is "claude". Ignored for other providers.
+   * Default: false
+   */
+  promptCaching?: boolean;
+  /**
+   * [Claude only] Enable Anthropic automatic prompt caching.
+   *
+   * When enabled, a top-level `cache_control: { type: "ephemeral" }` field is
+   * added to the request body. The server automatically places the cache
+   * breakpoint on the last cacheable block and moves it forward as
+   * conversations grow. No per-block markers are injected.
+   *
+   * Can be used independently or together with promptCaching (explicit breakpoints).
+   * When combined, the automatic breakpoint uses 1 of the 4 available slots.
+   * Only takes effect when provider is "claude". Ignored for other providers.
+   * Default: false
+   */
+  autoCaching?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/llm/factory.ts
+++ b/src/llm/factory.ts
@@ -33,6 +33,8 @@ export function createLLMFromConfig(config: LLMConfig, registry?: Pick<LLMProvid
         baseUrl: config.baseUrl,
         headers: config.headers,
         requestBody: config.requestBody,
+        promptCaching: config.promptCaching === true,
+        autoCaching: config.autoCaching === true,
       });
     case 'openai-responses':
       return createOpenAIResponsesProvider({

--- a/src/llm/formats/claude.ts
+++ b/src/llm/formats/claude.ts
@@ -13,7 +13,7 @@ import { consumeCallId, normalizeCallId, resolveCallId } from './tool-call-ids';
 import { sanitizeSchemaForClaude } from './schema-sanitizer';
 
 export class ClaudeFormat implements FormatAdapter {
-  constructor(private model: string) {}
+  constructor(private model: string, private promptCaching?: boolean, private autoCaching?: boolean) {}
 
   // ============ 编码请求：Gemini → Claude ============
 
@@ -155,6 +155,19 @@ export class ClaudeFormat implements FormatAdapter {
 
     // 流式参数
     if (stream) body.stream = true;
+
+    // Inject manual cache breakpoints when Prompt Caching is enabled.
+    // Follows Anthropic's cache prefix hierarchy: tools → system → messages.
+    // At most 3 breakpoints (Anthropic allows up to 4).
+    if (this.promptCaching) {
+      this.injectCacheBreakpoints(body);
+    }
+
+    // Inject top-level automatic caching marker.
+    // The server places the breakpoint on the last cacheable block automatically.
+    if (this.autoCaching) {
+      (body as any).cache_control = { type: 'ephemeral' };
+    }
 
     return body;
   }
@@ -321,6 +334,51 @@ export class ClaudeFormat implements FormatAdapter {
       inputTokens: 0,
       inThinkingBlock: false,
     } as ClaudeStreamState;
+  }
+
+  /**
+   * Inject manual cache breakpoints for Anthropic Prompt Caching.
+   *
+   * Cache prefix hierarchy (order matters):
+   *   1. tools    — mark the last tool definition
+   *   2. system   — convert string to content-block array, mark the last block
+   *   3. messages — mark the last content block of the last user message
+   */
+  private injectCacheBreakpoints(body: Record<string, unknown>): void {
+    const cacheControl = { type: 'ephemeral' as const };
+
+    // 1. Mark the last tool definition
+    const tools = body.tools as any[] | undefined;
+    if (tools && tools.length > 0) {
+      tools[tools.length - 1].cache_control = cacheControl;
+    }
+
+    // 2. Convert system from string to content-block array and mark it.
+    //    Anthropic accepts system as either a string or an array of content blocks;
+    //    the array form is required to attach cache_control.
+    if (typeof body.system === 'string' && body.system) {
+      body.system = [
+        { type: 'text', text: body.system, cache_control: cacheControl },
+      ];
+    } else if (Array.isArray(body.system) && body.system.length > 0) {
+      (body.system as any[])[body.system.length - 1].cache_control = cacheControl;
+    }
+
+    // 3. Mark the last content block of the last user message.
+    //    This caches the entire conversation history prefix.
+    const messages = body.messages as any[] | undefined;
+    if (messages && messages.length > 0) {
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const msg = messages[i];
+        if (msg.role === 'user' && Array.isArray(msg.content) && msg.content.length > 0) {
+          const lastBlock = msg.content[msg.content.length - 1];
+          if (typeof lastBlock === 'object' && lastBlock !== null) {
+            lastBlock.cache_control = cacheControl;
+          }
+          break;
+        }
+      }
+    }
   }
 }
 

--- a/src/llm/providers/claude.ts
+++ b/src/llm/providers/claude.ts
@@ -11,6 +11,8 @@ export interface ClaudeProviderConfig {
   baseUrl?: string;
   headers?: Record<string, string>;
   requestBody?: Record<string, unknown>;
+  promptCaching?: boolean;
+  autoCaching?: boolean;
 }
 
 export function createClaudeProvider(config: ClaudeProviderConfig): LLMProvider {
@@ -18,7 +20,7 @@ export function createClaudeProvider(config: ClaudeProviderConfig): LLMProvider 
   const baseUrl = (config.baseUrl || 'https://api.anthropic.com/v1').replace(/\/+$/, '');
 
   return new LLMProvider(
-    new ClaudeFormat(model),
+    new ClaudeFormat(model, config.promptCaching, config.autoCaching),
     {
       url: `${baseUrl}/messages`,
       headers: {


### PR DESCRIPTION
## 改动

为 Claude 渠道增加 Prompt Caching 配置支持，提供两个独立开关：

### `promptCaching` — 手动缓存断点

启用后，在请求体的关键位置自动注入 `cache_control: { type: "ephemeral" }` 标记：

| 层级 | 位置 | 说明 |
| :-- | :-- | :-- |
| tools | 最后一个 tool 定义 | 缓存工具声明 |
| system | system 指令（转为 content block 数组） | 缓存系统提示词 |
| messages | 最后一条 user 消息的最后一个 content block | 缓存历史消息前缀 |

最多使用 3 个断点（Anthropic 限制为 4 个）。

### `autoCaching` — 自动缓存

启用后，在请求体顶层添加 `cache_control: { type: "ephemeral" }`，由服务端自动将断点放在最后一个可缓存块上，每轮自动前移。

两个选项可独立使用，也可组合使用（自动缓存占用 4 个断点中的 1 个）。

## 配置示例

```yaml
models:
  claude_sonnet:
    provider: claude
    apiKey: your-api-key
    model: claude-sonnet-4-6
    baseUrl: https://api.anthropic.com/v1
    promptCaching: true
    autoCaching: true
```

## 原因

利用 Anthropic Prompt Caching 功能，在长上下文对话和频繁工具调用场景下降低 token 成本（缓存读取仅为基础价格的 10%）和响应延迟。

## 涉及文件

- `src/config/types.ts` — LLMConfig 类型新增字段
- `src/config/llm.ts` — YAML 配置解析
- `src/llm/factory.ts` — 工厂函数 fallback 路径
- `src/llm/providers/claude.ts` — Provider 创建
- `src/llm/formats/claude.ts` — 核心：缓存断点注入逻辑
- `src/bootstrap/extensions.ts` — **运行时实际执行的工厂函数**（关键修复点）
- `data/configs.example/llm.yaml` — 示例配置及注释

---

## 排障日记

### 症状

`llm.yaml` 中 Claude 模型配置了 `promptCaching: true`，但实际 API 请求中没有注入任何 `cache_control` 标记。代理网关后台显示 Iris 的请求没有缓存创建/读取，而同一个端点的 Lim-Code 请求缓存正常。

### 排查过程

#### 1. 首先怀疑注入逻辑有问题

编写测试验证 `ClaudeFormat.injectCacheBreakpoints()` 的输出。测试通过，三个断点（tools / system / messages）全部正确注入。

**结论：注入逻辑本身没问题。**

#### 2. 怀疑 user message content 格式问题

发现 Iris 的普通文本 user 消息的 `content` 是字符串而非数组，导致断点无法挂载。修复了 `injectCacheBreakpoints` 中的处理逻辑，将字符串 content 转为 content-block 数组。

**结论：确实是一个 bug，但修复后问题仍然存在。**

#### 3. 怀疑代理网关不支持 cache_control

搜索了 Anthropic 代理网关兼容性问题。但用户指出同一个代理端点 Lim-Code 能正常创建缓存。

**结论：排除代理网关问题。**

#### 4. 开启请求日志，查看实际发出的请求体

在 `system.yaml` 中开启 `logRequests: true`。检查日志文件发现：实际发出的请求体中 `system` 是字符串、`tools` 没有 `cache_control`、`messages` 也没有。三个断点全部没有注入。

**结论：`injectCacheBreakpoints()` 在运行时根本没有被调用。**

#### 5. 添加 debug 日志，逐层追踪配置传递链路

| 位置 | 打印结果 |
|---|---|
| `parseSingleLLMConfig` (config/llm.ts) | `promptCaching: true` ✅ |
| `createLLMFromConfig` 入口 (factory.ts) | `promptCaching: true` ✅ |
| `createClaudeProvider` 入口 (providers/claude.ts) | `promptCaching: undefined` ❌ |
| `ClaudeFormat` 构造函数 (formats/claude.ts) | `promptCaching: undefined` ❌ |

**结论：配置在 `createLLMFromConfig` → `createClaudeProvider` 这一步丢失。**

#### 6. 在 factory.ts 的 case 'claude' 块内添加日志

**关键发现：这行 debug 日志根本没有打印出来！** `switch case 'claude'` 分支在运行时从未被执行。

#### 7. 根因定位

```typescript
// factory.ts
const registeredFactory = registry?.get(config.provider);
if (registeredFactory) return registeredFactory(config);  // ← 直接 return
switch (config.provider) {
    case 'claude':  // ← 永远走不到
}
```

`bootstrap/extensions.ts` 中所有内置 provider 都通过 `llmProviders.register()` 注册了工厂函数，运行时 `registeredFactory` 命中后直接 return，`switch case` 根本不会执行。

而 `extensions.ts` 注册的 claude 工厂只传了 5 个字段，没有 `promptCaching` 和 `autoCaching`。

### 根因

`src/bootstrap/extensions.ts` 中注册的内置 claude 工厂函数**优先于** `src/llm/factory.ts` 中的 `switch case` 执行。我们只在 `factory.ts` 里添加了字段传递，但该代码在运行时永远不会被执行。真正被调用的 `extensions.ts` 工厂没有传递这两个字段。

### 预防措施

在 `extensions.ts` 和 `factory.ts` 两处添加醒目中文注释，说明运行时优先级关系，防止同类问题再次发生。
