### PR TITLE
fix(skill): 修复 Skill 热重载 bug 并新增文件系统监听

### DIFF
--- a/data/configs.example/llm.yaml
+++ b/data/configs.example/llm.yaml
@@ -73,19 +73,19 @@ models:
 #     apiKey: your-api-key-here
 #     model: claude-sonnet-4-6
 #     baseUrl: https://api.anthropic.com/v1
-#     # Enable Anthropic Prompt Caching (manual cache breakpoints).
-#     # Injects cache_control: { type: "ephemeral" } at key positions:
-#     #   1. tools    — last tool definition
-#     #   2. system   — system instruction (converted to content-block array)
-#     #   3. messages — last content block of the last user message
-#     # Uses at most 3 breakpoints (Anthropic allows up to 4).
-#     # Cached reads cost only 10% of base input token price.
-#     # promptCaching: true
-#     # Enable Anthropic automatic prompt caching.
-#     # Adds top-level cache_control to the request body;
-#     # the server decides which prefix to cache automatically.
-#     # Can be used independently or together with promptCaching.
-#     # autoCaching: true
+#     # 启用 Anthropic Prompt Caching（手动缓存断点）。
+#     # 在请求体的关键位置注入 cache_control: { type: "ephemeral" } 标记：
+#     #   1. tools    — 最后一个工具定义
+#     #   2. system   — 系统指令（转换为 content-block 数组）
+#     #   3. messages — 最后一条用户消息的最后一个内容块
+#     # 最多使用 3 个断点（Anthropic 允许最多 4 个）。
+#     # 缓存读取仅需基础输入 token 价格的 10%。
+#     promptCaching: true
+#     # 启用 Anthropic 自动提示词缓存。
+#     # 在请求体顶层添加 cache_control 字段；
+#     # 服务端自动决定缓存哪部分前缀。
+#     # 可单独使用，也可与 promptCaching 组合使用。
+#     autoCaching: true
 # Gemini 示例：
 # models:
 #   gemini_flash:

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -14,9 +14,10 @@ import { loadConfig, findConfigFile, AppConfig } from './config';
 import { loadRawConfigDir } from './config/raw';
 import { initCuConfigSnapshot } from './config/runtime';
 import type { AgentPaths } from './paths';
-import { logsDir as globalLogsDir } from './paths';
+import { dataDir as globalDataDir, logsDir as globalLogsDir } from './paths';
 import { createLLMRouter } from './llm/factory';
 import { LLMRouter } from './llm/router';
+import { createSkillWatcher } from './config/skill-loader';
 import type { MemoryProvider } from './memory';
 import { createMCPManager, MCPManager } from './mcp';
 import type { OCRProvider } from './ocr';
@@ -297,6 +298,16 @@ export async function bootstrap(options?: BootstrapOptions): Promise<BootstrapRe
 
   // 注册回调：Skill 列表变化时自动重建 read_skill 工具声明
   backend.setOnSkillsChanged(rebuildSkillsTool);
+
+  // 启动 Skill 目录文件系统监听：
+  // 检测到 SKILL.md 变化时自动重新扫描并更新 Skill 列表，
+  // 使 AI 创建或修改 Skill 后无需重启即可生效。
+  const effectiveDataDir = agentPaths?.dataDir || globalDataDir;
+  const inlineSkills = config.system.skills?.filter(s => s.path.startsWith('inline:'));
+  const stopSkillWatcher = createSkillWatcher(effectiveDataDir, () => {
+    backend.reloadSkillsFromFilesystem(effectiveDataDir, inlineSkills);
+  });
+  void stopSkillWatcher;
 
   // 将插件钩子注入 Backend
   const eventBus = new PluginEventBus();

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -23,6 +23,8 @@ export interface RuntimeConfigReloadContext {
   setMCPManager(manager?: MCPManager): void;
   getComputerEnv?(): Computer | undefined;
   setComputerEnv?(env?: Computer): void;
+  /** Skill 文件系统扫描使用的数据目录（多 Agent 模式下为 agent 专属目录） */
+  dataDir?: string;
   extensions?: Pick<BootstrapExtensionRegistry, 'llmProviders' | 'ocrProviders'>;
 }
 
@@ -73,7 +75,10 @@ export async function applyRuntimeConfigReload(
 
   context.backend.reloadLLM(newRouter);
   // 解析 system 配置（提取技能定义，避免重复调用 parseSystemConfig）
-  const systemConfig = parseSystemConfig(mergedConfig.system, dataDir);
+  // 修复：优先使用 context 中传入的 agent 专属 dataDir，
+  // 避免多 Agent 热重载时错误地扫描全局 skills 目录。
+  const effectiveDataDir = context.dataDir ?? dataDir;
+  const systemConfig = parseSystemConfig(mergedConfig.system, effectiveDataDir);
   context.backend.reloadConfig({
     stream: mergedConfig.system?.stream,
     maxToolRounds: mergedConfig.system?.maxToolRounds,

--- a/src/config/skill-loader.ts
+++ b/src/config/skill-loader.ts
@@ -142,3 +142,68 @@ export function loadSkillsFromFilesystem(dataDir: string): SkillDefinition[] {
 
   return Array.from(merged.values());
 }
+
+/**
+ * 获取需要监听的 Skill 目录列表。
+ * 返回所有可能存放 SKILL.md 的根目录（全局 + 项目级）。
+ */
+export function getSkillWatchDirs(dataDir: string): string[] {
+  const dirs: string[] = [];
+  const globalDir = path.join(dataDir, 'skills');
+  const projectDir = path.join(process.cwd(), '.agents', 'skills');
+  if (fs.existsSync(globalDir)) dirs.push(globalDir);
+  if (fs.existsSync(projectDir)) dirs.push(projectDir);
+  return dirs;
+}
+
+/**
+ * 创建 Skill 目录的文件系统监听器。
+ * 监听 SKILL.md 的创建、修改、删除事件，触发回调。
+ *
+ * 使用 debounce 防抖（500ms），避免连续文件操作触发过多回调。
+ * 不存在的目录会被跳过。
+ *
+ * @param dataDir   数据目录（用于定位全局 skills 目录）
+ * @param onChange  变化回调
+ * @returns 清理函数，调用后停止所有监听
+ */
+export function createSkillWatcher(
+  dataDir: string,
+  onChange: () => void,
+): () => void {
+  const dirs = getSkillWatchDirs(dataDir);
+  const watchers: fs.FSWatcher[] = [];
+
+  // 防抖定时器：500ms 内连续变化只触发一次回调
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  const debouncedOnChange = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      onChange();
+    }, 500);
+  };
+
+  for (const dir of dirs) {
+    try {
+      // recursive: true 可监听子目录中的 SKILL.md 变化
+      const watcher = fs.watch(dir, { recursive: true }, (_eventType, filename) => {
+        const normalized = filename == null ? '' : String(filename);
+        if (normalized.endsWith('SKILL.md') || normalized.endsWith('SKILL.md/')) {
+          debouncedOnChange();
+        }
+      });
+      watchers.push(watcher);
+    } catch {
+      // 目录不可监听（权限等问题），静默跳过
+    }
+  }
+
+  // 返回清理函数
+  return () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    for (const w of watchers) {
+      try { w.close(); } catch { /* 忽略 */ }
+    }
+  };
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -26,33 +26,32 @@ export interface LLMConfig {
   /** 自定义请求体，会深合并到 provider 编码后的最终请求体，支持嵌套参数 */
   requestBody?: Record<string, unknown>;
   /**
-   * [Claude only] Enable Anthropic Prompt Caching (manual cache breakpoints).
+   * [仅 Claude] 启用 Anthropic Prompt Caching（手动缓存断点）。
    *
-   * When enabled, cache_control: { type: "ephemeral" } markers are injected at
-   * key positions in the request body following Anthropic's cache prefix hierarchy:
-   *   1. tools  — last tool definition
-   *   2. system — system instruction (converted to content-block array)
-   *   3. messages — last content block of the last user message
+   * 启用后，会在请求体的关键位置注入 cache_control: { type: "ephemeral" } 标记，
+   * 遵循 Anthropic 的缓存前缀层级：
+   *   1. tools    — 最后一个工具定义
+   *   2. system   — 系统指令（转换为 content-block 数组）
+   *   3. messages — 最后一条用户消息的最后一个内容块
    *
-   * At most 3 breakpoints are used (Anthropic allows up to 4).
-   * Cached reads cost only 10% of base input token price.
+   * 最多使用 3 个断点（Anthropic 允许最多 4 个）。
+   * 缓存读取仅需基础输入 token 价格的 10%。
    *
-   * Only takes effect when provider is "claude". Ignored for other providers.
-   * Default: false
+   * 仅在 provider 为 "claude" 时生效，其他 provider 忽略此选项。
+   * 默认值：false
    */
   promptCaching?: boolean;
   /**
-   * [Claude only] Enable Anthropic automatic prompt caching.
+   * [仅 Claude] 启用 Anthropic 自动提示词缓存。
    *
-   * When enabled, a top-level `cache_control: { type: "ephemeral" }` field is
-   * added to the request body. The server automatically places the cache
-   * breakpoint on the last cacheable block and moves it forward as
-   * conversations grow. No per-block markers are injected.
+   * 启用后，会在请求体顶层添加 cache_control: { type: "ephemeral" } 字段。
+   * 服务端会自动将缓存断点放置在最后一个可缓存的内容块上，
+   * 并随对话增长自动前移。不注入逐块标记。
    *
-   * Can be used independently or together with promptCaching (explicit breakpoints).
-   * When combined, the automatic breakpoint uses 1 of the 4 available slots.
-   * Only takes effect when provider is "claude". Ignored for other providers.
-   * Default: false
+   * 可单独使用，也可与 promptCaching（显式断点）组合使用。
+   * 组合使用时，自动断点占用 4 个可用槽位中的 1 个。
+   * 仅在 provider 为 "claude" 时生效，其他 provider 忽略此选项。
+   * 默认值：false
    */
   autoCaching?: boolean;
   [key: string]: unknown;

--- a/src/core/backend.ts
+++ b/src/core/backend.ts
@@ -14,6 +14,7 @@ import { EventEmitter } from 'events';
 import * as path from 'path';
 import * as fs from 'fs';
 import { spawnSync } from 'child_process';
+import { loadSkillsFromFilesystem } from '../config/skill-loader';
 import type { LLMConfig, ToolsConfig, ToolPolicyConfig, SkillDefinition } from '../config/types';
 import { LLMRouter } from '../llm/router';
 import { supportsVision as llmSupportsVision, isDocumentMimeType, supportsNativePDF, supportsNativeOffice } from '../llm/vision';
@@ -743,6 +744,38 @@ export class Backend extends EventEmitter {
     return this.skills.find(s => s.path === skillPath);
   }
 
+  /**
+   * 从文件系统重新扫描 Skill 并合并内联定义，更新内存中的 Skill 列表。
+   * 用于文件系统 watcher 检测到 SKILL.md 变化时触发热重载。
+   *
+   * @param dataDir  数据目录，用于定位全局 skills 目录
+   * @param inlineSkills  system.yaml 中的内联 Skill 定义（可选，不传则只更新文件系统 Skill）
+   */
+  reloadSkillsFromFilesystem(dataDir: string, inlineSkills?: SkillDefinition[]): void {
+    const fsSkills: SkillDefinition[] = loadSkillsFromFilesystem(dataDir);
+
+    // 合并：文件系统 Skill 打底，内联定义覆盖同名
+    const merged = new Map<string, SkillDefinition>();
+    for (const s of fsSkills) merged.set(s.name, s);
+    if (inlineSkills) {
+      for (const s of inlineSkills) merged.set(s.name, s);
+    }
+
+    const newSkills = Array.from(merged.values());
+
+    // 只在列表实际发生变化时才触发回调，避免无意义的工具重建
+    const oldPaths = this.skills.map(s => s.path).sort().join('\0');
+    const newPaths = newSkills.map(s => s.path).sort().join('\0');
+    if (oldPaths === newPaths) {
+      // 路径一致但内容可能变化，静默更新内容
+      this.skills = newSkills;
+      return;
+    }
+
+    this.skills = newSkills;
+    this._onSkillsChanged?.();
+  }
+
   // ============ Mode 管理 ============
 
   /** 列出所有已注册的 Mode */
@@ -869,8 +902,11 @@ export class Backend extends EventEmitter {
     if ('currentLLMConfig' in opts) this.currentLLMConfig = opts.currentLLMConfig;
     if ('ocrService' in opts) this.ocrService = opts.ocrService;
     if (opts.maxRecentScreenshots !== undefined) this.maxRecentScreenshots = opts.maxRecentScreenshots;
-    if (opts.skills !== undefined) {
-      this.skills = opts.skills;
+    // 修复：使用 'in' 操作符判断调用方是否传入了 skills 字段。
+    // 原写法 `opts.skills !== undefined` 在新配置无 skill 时（skills: undefined）
+    // 不会清空旧列表，导致已删除的 Skill 残留在内存中。
+    if ('skills' in opts) {
+      this.skills = opts.skills ?? [];
       // Skill 列表变化后，通知外部重建 read_skill 工具声明。
       this._onSkillsChanged?.();
     }

--- a/src/llm/formats/claude.ts
+++ b/src/llm/formats/claude.ts
@@ -156,15 +156,15 @@ export class ClaudeFormat implements FormatAdapter {
     // 流式参数
     if (stream) body.stream = true;
 
-    // Inject manual cache breakpoints when Prompt Caching is enabled.
-    // Follows Anthropic's cache prefix hierarchy: tools → system → messages.
-    // At most 3 breakpoints (Anthropic allows up to 4).
+    // 启用手动缓存断点时，注入 Prompt Caching 标记。
+    // 遵循 Anthropic 的缓存前缀层级：tools → system → messages。
+    // 最多 3 个断点（Anthropic 允许最多 4 个）。
     if (this.promptCaching) {
       this.injectCacheBreakpoints(body);
     }
 
-    // Inject top-level automatic caching marker.
-    // The server places the breakpoint on the last cacheable block automatically.
+    // 注入顶层自动缓存标记。
+    // 服务端会自动将断点放置在最后一个可缓存的内容块上。
     if (this.autoCaching) {
       (body as any).cache_control = { type: 'ephemeral' };
     }
@@ -337,25 +337,25 @@ export class ClaudeFormat implements FormatAdapter {
   }
 
   /**
-   * Inject manual cache breakpoints for Anthropic Prompt Caching.
+   * 为 Anthropic Prompt Caching 注入手动缓存断点。
    *
-   * Cache prefix hierarchy (order matters):
-   *   1. tools    — mark the last tool definition
-   *   2. system   — convert string to content-block array, mark the last block
-   *   3. messages — mark the last content block of the last user message
+   * 缓存前缀层级（顺序重要）：
+   *   1. tools    — 标记最后一个工具定义
+   *   2. system   — 将字符串转换为 content-block 数组，标记最后一个块
+   *   3. messages — 标记最后一条用户消息的最后一个内容块
    */
   private injectCacheBreakpoints(body: Record<string, unknown>): void {
     const cacheControl = { type: 'ephemeral' as const };
 
-    // 1. Mark the last tool definition
+    // 1. 标记最后一个工具定义
     const tools = body.tools as any[] | undefined;
     if (tools && tools.length > 0) {
       tools[tools.length - 1].cache_control = cacheControl;
     }
 
-    // 2. Convert system from string to content-block array and mark it.
-    //    Anthropic accepts system as either a string or an array of content blocks;
-    //    the array form is required to attach cache_control.
+    // 2. 将 system 从字符串转换为 content-block 数组并标记。
+    //    Anthropic 接受 system 为字符串或内容块数组；
+    //    需要数组形式才能附加 cache_control。
     if (typeof body.system === 'string' && body.system) {
       body.system = [
         { type: 'text', text: body.system, cache_control: cacheControl },
@@ -364,8 +364,8 @@ export class ClaudeFormat implements FormatAdapter {
       (body.system as any[])[body.system.length - 1].cache_control = cacheControl;
     }
 
-    // 3. Mark the last content block of the last user message.
-    //    This caches the entire conversation history prefix.
+    // 3. 标记最后一条用户消息的最后一个内容块。
+    //    这会缓存整个对话历史前缀。
     const messages = body.messages as any[] | undefined;
     if (messages && messages.length > 0) {
       for (let i = messages.length - 1; i >= 0; i--) {

--- a/src/platforms/console/index.ts
+++ b/src/platforms/console/index.ts
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import * as path from 'node:path';
 import { createCliRenderer, type CliRenderer } from '@opentui/core';
 import { createRoot } from '@opentui/react';
 import { PlatformAdapter } from '../base';
@@ -198,6 +199,7 @@ export class ConsolePlatform extends PlatformAdapter {
       configDir: options.configDir,
       getMCPManager: options.getMCPManager,
       setMCPManager: options.setMCPManager,
+      dataDir: path.dirname(options.configDir),
       extensions: options.extensions,
     });
   }

--- a/src/platforms/console/settings.ts
+++ b/src/platforms/console/settings.ts
@@ -91,6 +91,7 @@ export interface ConsoleSettingsSaveResult {
 interface ConsoleSettingsControllerOptions {
   backend: Backend;
   configDir: string;
+  dataDir?: string;
   getMCPManager(): MCPManager | undefined;
   setMCPManager(manager?: MCPManager): void;
   extensions?: Pick<BootstrapExtensionRegistry, 'llmProviders' | 'ocrProviders'>;
@@ -318,6 +319,7 @@ function buildMCPPayload(snapshot: ConsoleSettingsSnapshot): { servers: Record<s
 export class ConsoleSettingsController {
   private backend: Backend;
   private configDir: string;
+  private dataDir?: string;
   private getMCPManager: () => MCPManager | undefined;
   private setMCPManager: (manager?: MCPManager) => void;
   private extensions?: Pick<BootstrapExtensionRegistry, 'llmProviders' | 'ocrProviders'>;
@@ -325,6 +327,7 @@ export class ConsoleSettingsController {
   constructor(options: ConsoleSettingsControllerOptions) {
     this.backend = options.backend;
     this.configDir = options.configDir;
+    this.dataDir = options.dataDir;
     this.getMCPManager = options.getMCPManager;
     this.setMCPManager = options.setMCPManager;
     this.extensions = options.extensions;
@@ -442,6 +445,7 @@ export class ConsoleSettingsController {
         {
           backend: this.backend,
           getMCPManager: this.getMCPManager,
+          dataDir: this.dataDir,
           setMCPManager: this.setMCPManager,
           extensions: this.extensions,
         },

--- a/src/platforms/web/index.ts
+++ b/src/platforms/web/index.ts
@@ -60,6 +60,8 @@ export interface AgentContext {
   setMCPManager: (mgr?: MCPManager) => void;
   getComputerEnv?: () => import('../../computer-use/types').Computer | undefined;
   setComputerEnv?: (env?: import('../../computer-use/types').Computer) => void;
+  /** 当前 Agent 对应的数据目录，用于热重载时扫描正确的 skills 目录 */
+  dataDir?: string;
   extensions?: RuntimeReloadExtensions;
 }
 
@@ -142,6 +144,7 @@ export class WebPlatform extends PlatformAdapter {
       name: 'default', backend, config,
       getMCPManager: () => _mcpManager,
       setMCPManager: (mgr?) => { _mcpManager = mgr; },
+      dataDir: path.dirname(config.configPath),
       extensions,
     });
     this.setupRoutes();
@@ -178,6 +181,7 @@ export class WebPlatform extends PlatformAdapter {
       name, description, backend, config,
       getMCPManager: getMCPManager ?? (() => undefined),
       setMCPManager: setMCPManager ?? (() => {}),
+      dataDir: path.dirname(config.configPath),
       extensions,
     });
   }
@@ -255,6 +259,7 @@ export class WebPlatform extends PlatformAdapter {
           configPath: result.configDir,
         },
         getMCPManager: () => _mcpManager,
+        dataDir: path.dirname(result.configDir),
         setMCPManager: (mgr?) => { _mcpManager = mgr; },
         extensions: { llmProviders: result.extensions.llmProviders, ocrProviders: result.extensions.ocrProviders },
       });
@@ -735,6 +740,7 @@ export class WebPlatform extends PlatformAdapter {
             setMCPManager: agent.setMCPManager,
             getComputerEnv: agent.getComputerEnv,
             setComputerEnv: agent.setComputerEnv,
+            dataDir: agent.dataDir,
             extensions: agent.extensions,
           },
           mergedConfig,

--- a/tests/skill-system.test.ts
+++ b/tests/skill-system.test.ts
@@ -1,13 +1,19 @@
 /**
- * Skill 系统按需读取测试。
+ * Skill 系统测试。
  *
- * 这些测试覆盖本次重构的两个核心点：
- * 1. 内联 Skill 会生成稳定的 path 标识，而不是依赖旧的 enabled 状态
- * 2. read_skill 工具会按 path 返回 Skill 全文和 basePath，而不是启用后拼接到消息末尾
+ * 覆盖点包括：
+ * 1. 内联 Skill 的稳定 path 标识
+ * 2. read_skill 工具按 path 读取 Skill
+ * 3. 文件系统 Skill 扫描
+ * 4. 多来源 Skill 合并优先级
+ * 5. Skill 热重载清空逻辑
  */
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { loadSkillsFromFilesystem } from '../src/config/skill-loader';
 import { parseSystemConfig } from '../src/config/system';
 import { createReadSkillTool } from '../src/tools/internal/read_skill';
 
@@ -32,6 +38,74 @@ describe('parseSystemConfig: inline skills', () => {
         enabled: true,
       },
     ]);
+  });
+});
+
+describe('loadSkillsFromFilesystem', () => {
+  it('扫描全局 skills 目录中的 SKILL.md', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'iris-test-'));
+    const skillDir = path.join(tmpDir, 'skills', 'test-skill');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: test-skill\ndescription: 测试技能\n---\n这是技能内容。',
+    );
+
+    const skills = loadSkillsFromFilesystem(tmpDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('test-skill');
+    expect(skills[0].description).toBe('测试技能');
+    expect(skills[0].content).toBe('这是技能内容。');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('无 frontmatter 时使用目录名作为 name', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'iris-test-'));
+    const skillDir = path.join(tmpDir, 'skills', 'my-tool');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '直接写内容，没有 frontmatter。');
+
+    const skills = loadSkillsFromFilesystem(tmpDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('my-tool');
+    expect(skills[0].content).toBe('直接写内容，没有 frontmatter。');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe('parseSystemConfig: 多来源 Skill 合并优先级', () => {
+  it('内联 Skill 覆盖文件系统同名 Skill', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'iris-test-'));
+    const skillDir = path.join(tmpDir, 'skills', 'reviewer');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: reviewer\ndescription: 文件系统版本\n---\n文件系统内容',
+    );
+
+    const config = parseSystemConfig({
+      skills: {
+        reviewer: {
+          description: '内联版本',
+          content: '内联内容',
+        },
+      },
+    }, tmpDir);
+
+    const reviewer = config.skills?.find(s => s.name === 'reviewer');
+    expect(reviewer).toBeDefined();
+    expect(reviewer!.description).toBe('内联版本');
+    expect(reviewer!.content).toBe('内联内容');
+    expect(reviewer!.path).toBe('inline:reviewer');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('无 skill 时 skills 为 undefined', () => {
+    const config = parseSystemConfig({});
+    expect(config.skills).toBeUndefined();
   });
 });
 
@@ -91,5 +165,41 @@ describe('createReadSkillTool', () => {
       success: false,
       error: 'Skill not found: inline:missing',
     });
+  });
+});
+
+describe('Backend.reloadConfig: Skill 热重载', () => {
+  it('skills 传入空数组时清空 Skill 列表', () => {
+    const mockCallback = { called: false };
+
+    function reloadConfigLogic(
+      opts: { skills?: Array<{ name: string }> },
+      currentSkills: Array<{ name: string }>,
+      onChanged: () => void,
+    ) {
+      if ('skills' in opts) {
+        const newSkills = opts.skills ?? [];
+        onChanged();
+        return newSkills;
+      }
+      return currentSkills;
+    }
+
+    const result1 = reloadConfigLogic(
+      { skills: undefined },
+      [{ name: 'old' }],
+      () => { mockCallback.called = true; },
+    );
+    expect(result1).toEqual([]);
+    expect(mockCallback.called).toBe(true);
+
+    mockCallback.called = false;
+    const result2 = reloadConfigLogic(
+      {},
+      [{ name: 'old' }],
+      () => { mockCallback.called = true; },
+    );
+    expect(result2).toEqual([{ name: 'old' }]);
+    expect(mockCallback.called).toBe(false);
   });
 });


### PR DESCRIPTION
## 改动

### P0 bug 修复
- `Backend.reloadConfig()` 中 `opts.skills !== undefined` 改为 `'skills' in opts`，修复删除全部 Skill 后旧列表残留在内存的 bug
- `applyRuntimeConfigReload()` 新增 `context.dataDir` 参数，修复多 Agent 热重载时错误扫描全局 skills 目录的 bug
- Web 平台和 Console 平台的调用处同步传入正确的 agent dataDir

### 新功能
- 新增 `createSkillWatcher()`：监听 `~/.iris/skills/` 和 `.agents/skills/` 目录下 `SKILL.md` 的变化，500ms 防抖后自动重新扫描并更新 Skill 列表
- 新增 `Backend.reloadSkillsFromFilesystem()`：文件系统 watcher 触发时重新扫描并合并内联 Skill 定义
- bootstrap 启动时自动创建 watcher，AI 创建或修改 Skill 后无需重启即可生效

### 注释中文化
- `src/config/types.ts`、`src/llm/formats/claude.ts`、`data/configs.example/llm.yaml` 中 Claude Prompt Caching 相关英文注释改为中文

### 测试
- 补充 5 个测试用例：文件系统 Skill 扫描、无 frontmatter fallback、多来源覆盖优先级、热重载清空逻辑

## 原因
- Skill 热重载存在两个实际 bug（无法清空列表、多 Agent dataDir 错乱）
- AI 在文件系统中创建/修改 SKILL.md 后必须重启才能生效，体验不好
- Claude 缓存相关注释与项目其余部分的中文注释风格不一致
