### PR TITLE
fix: 修复 extensions.ts 工厂未传递 promptCaching/autoCaching 导致缓存不生效

### DIFF
--- a/src/bootstrap/extensions.ts
+++ b/src/bootstrap/extensions.ts
@@ -64,6 +64,13 @@ export interface BootstrapExtensionRegistry {
 }
 
 /** 创建并注册内置扩展 */
+//
+// ⚠️  注意：此处注册的工厂函数才是运行时实际执行的代码路径。
+//    factory.ts 中的 switch-case 仅在 registry 中无对应条目时作为 fallback。
+//    新增 provider 配置字段时，必须同时更新：
+//      1. 本文件 (extensions.ts) — 注册的工厂函数
+//      2. factory.ts — switch-case fallback
+//
 export function createBootstrapExtensionRegistry(): BootstrapExtensionRegistry {
   const llmProviders = new LLMProviderFactoryRegistry();
   llmProviders.register('gemini', (config) => createGeminiProvider({
@@ -86,6 +93,8 @@ export function createBootstrapExtensionRegistry(): BootstrapExtensionRegistry {
     baseUrl: config.baseUrl,
     headers: config.headers,
     requestBody: config.requestBody,
+    promptCaching: config.promptCaching === true,
+    autoCaching: config.autoCaching === true,
   }));
   llmProviders.register('openai-responses', (config) => createOpenAIResponsesProvider({
     apiKey: config.apiKey,

--- a/src/llm/factory.ts
+++ b/src/llm/factory.ts
@@ -14,6 +14,12 @@ import { LLMRouter } from './router';
 import { LLMConfig, LLMRegistryConfig } from '../config/types';
 import type { LLMProviderFactoryRegistry } from '../bootstrap/extensions';
 
+//
+// ⚠️  注意：此 switch-case 仅为 fallback。
+//    运行时优先使用 bootstrap/extensions.ts 中注册的工厂函数
+//    （下方 registeredFactory 判断会先行 return）。
+//    新增配置字段时，必须同步更新 extensions.ts。
+//
 export function createLLMFromConfig(config: LLMConfig, registry?: Pick<LLMProviderFactoryRegistry, 'get'>): LLMProviderLike {
   const registeredFactory = registry?.get(config.provider);
   if (registeredFactory) return registeredFactory(config);

--- a/src/llm/formats/claude.ts
+++ b/src/llm/formats/claude.ts
@@ -370,13 +370,21 @@ export class ClaudeFormat implements FormatAdapter {
     if (messages && messages.length > 0) {
       for (let i = messages.length - 1; i >= 0; i--) {
         const msg = messages[i];
-        if (msg.role === 'user' && Array.isArray(msg.content) && msg.content.length > 0) {
+        if (msg.role !== 'user') continue;
+
+        // Plain-text user messages use content as a string; convert to
+        // content-block array so we can attach cache_control.
+        if (typeof msg.content === 'string') {
+          msg.content = [{ type: 'text', text: msg.content }];
+        }
+
+        if (Array.isArray(msg.content) && msg.content.length > 0) {
           const lastBlock = msg.content[msg.content.length - 1];
           if (typeof lastBlock === 'object' && lastBlock !== null) {
             lastBlock.cache_control = cacheControl;
           }
-          break;
         }
+        break;
       }
     }
   }


### PR DESCRIPTION
## 改动

修复 PR #16 引入的 Anthropic Prompt Caching 功能在运行时不生效的问题。

### 根因

`src/bootstrap/extensions.ts` 中注册的内置工厂函数是运行时**实际执行的代码路径**，优先于 `factory.ts` 的 `switch case`（后者仅为 fallback）。PR #16 只在 `factory.ts` 中添加了 `promptCaching` / `autoCaching` 字段传递，但该代码在运行时永远不会被执行。

### 修复内容

1. **`src/bootstrap/extensions.ts`** — claude 工厂注册补充 `promptCaching` / `autoCaching` 字段传递
2. **`src/llm/formats/claude.ts`** — `injectCacheBreakpoints` 兼容纯文本 user message（`string` → `content-block array` 转换）
3. **`src/bootstrap/extensions.ts` + `src/llm/factory.ts`** — 添加防御性中文注释，说明运行时优先级关系，防止同类问题再次发生

---

## 排障日记

### 症状

`llm.yaml` 中 Claude 模型配置了 `promptCaching: true`，但实际 API 请求中没有注入任何 `cache_control` 标记。代理网关后台显示 Iris 的请求没有缓存创建/读取，而同一个端点的 Lim-Code 请求缓存正常。

### 排查过程

#### 1. 首先怀疑注入逻辑有问题

编写测试验证 `ClaudeFormat.injectCacheBreakpoints()` 的输出。测试通过，三个断点（tools / system / messages）全部正确注入。

**结论：注入逻辑本身没问题。**

#### 2. 怀疑 user message content 格式问题

发现 Iris 的普通文本 user 消息的 `content` 是字符串而非数组，导致断点无法挂载。修复了 `injectCacheBreakpoints` 中的处理逻辑，将字符串 content 转为 content-block 数组。

**结论：确实是一个 bug，但修复后问题仍然存在。**

#### 3. 怀疑代理网关不支持 cache_control

搜索了 Anthropic 代理网关兼容性问题。但用户指出同一个代理端点 Lim-Code 能正常创建缓存。

**结论：排除代理网关问题。**

#### 4. 开启请求日志，查看实际发出的请求体

在 `system.yaml` 中开启 `logRequests: true`。检查日志文件发现：实际发出的请求体中 `system` 是字符串、`tools` 没有 `cache_control`、`messages` 也没有。三个断点全部没有注入。

**结论：`injectCacheBreakpoints()` 在运行时根本没有被调用。**

#### 5. 添加 debug 日志，逐层追踪配置传递链路

| 位置 | 打印结果 |
|---|---|
| `parseSingleLLMConfig` (config/llm.ts) | `promptCaching: true` ✅ |
| `createLLMFromConfig` 入口 (factory.ts) | `promptCaching: true` ✅ |
| `createClaudeProvider` 入口 (providers/claude.ts) | `promptCaching: undefined` ❌ |
| `ClaudeFormat` 构造函数 (formats/claude.ts) | `promptCaching: undefined` ❌ |

**结论：配置在 `createLLMFromConfig` → `createClaudeProvider` 这一步丢失。**

#### 6. 在 factory.ts 的 case 'claude' 块内添加日志

**关键发现：这行 debug 日志根本没有打印出来！** `switch case 'claude'` 分支在运行时从未被执行。

#### 7. 根因定位

```typescript
// factory.ts
const registeredFactory = registry?.get(config.provider);
if (registeredFactory) return registeredFactory(config);  // ← 直接 return
switch (config.provider) {
    case 'claude':  // ← 永远走不到
}
```

`bootstrap/extensions.ts` 中所有内置 provider 都通过 `llmProviders.register()` 注册了工厂函数，运行时 `registeredFactory` 命中后直接 return，`switch case` 根本不会执行。而 `extensions.ts` 注册的 claude 工厂只传了 5 个字段，没有 `promptCaching` 和 `autoCaching`。

### 为什么排查花了这么长时间

1. `factory.ts` 的 `switch case` 看起来是「正确的入口」——函数名 `createLLMFromConfig`、参数类型 `LLMConfig`、调用方式都暗示它是主要的创建路径。实际上它只是 fallback。
2. `extensions.ts` 的 `register()` 调用在视觉上更像是「注册插件扩展点」，而非「创建 provider 的主路径」。这种心理预期导致排查时跳过了它。
3. debug 日志在函数入口处打印成功（`registeredFactory` 检查在入口之后），容易误导人认为「函数走到了 `switch case`」。只有在 `case 'claude'` 块内部添加日志才能发现它没被执行。
