### PR TITLE
fix: Docker build — ESM imports, stale path, missing runtime package

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -39,11 +39,22 @@ RUN cd src/platforms/web/web-ui && npm run build
 # ------ Stage 3: Compile TypeScript ------
 FROM deps AS build
 COPY src/ src/
+COPY packages/ packages/
 COPY tsconfig.json tsconfig.build.json ./
 COPY data/ data/
 # Overlay pre-built web-ui into source tree
 COPY --from=build-ui /app/src/platforms/web/web-ui/dist/ src/platforms/web/web-ui/dist/
 RUN npx tsc -p tsconfig.build.json
+# Fix ESM imports: Node.js ESM requires explicit .js extensions and does not
+# support directory imports (index.js auto-resolution) or tsconfig path aliases.
+# The bundler moduleResolution used by tsc emits bare specifiers that only work
+# with a bundler runtime (tsx/bun). This script rewrites them for plain Node.js.
+COPY deploy/docker/fix-esm-imports.cjs /tmp/fix-esm-imports.cjs
+RUN node /tmp/fix-esm-imports.cjs dist
+# Prepare compiled @iris/extension-utils with a Node-compatible package.json
+# (the source package.json points exports to .ts files which Node cannot run)
+RUN echo '{"name":"@iris/extension-utils","version":"0.1.0","type":"module","exports":{".":{"import":"./src/index.js"},"./package.json":"./package.json"}}' \
+    > dist/packages/extension-utils/package.json
 # Strip devDependencies — production image only needs runtime deps
 RUN npm prune --omit=dev
 
@@ -60,7 +71,7 @@ COPY src/ src/
 COPY tsconfig.json tsconfig.build.json ./
 COPY data/ data/
 COPY script/build.ts script/build.ts
-COPY onboard/ onboard/
+COPY terminal/ terminal/
 # Overlay pre-built web-ui
 COPY --from=build-ui /app/src/platforms/web/web-ui/dist/ src/platforms/web/web-ui/dist/
 
@@ -87,7 +98,7 @@ COPY --from=build /app/package.json .
 COPY --from=build /app/data/ data/
 # Web UI static files — resolvePublicDir() checks cwd/src/platforms/web/web-ui/dist
 COPY --from=build-ui /app/src/platforms/web/web-ui/dist/ src/platforms/web/web-ui/dist/
-# Bun-compiled binaries (TUI + onboard)
+# Bun-compiled binaries (TUI + terminal)
 COPY --from=bun-compile /app/dist/bin/iris-linux-x64/bin/iris bin/iris
 COPY --from=bun-compile /app/dist/bin/iris-linux-x64/bin/iris-onboard bin/iris-onboard
 RUN chmod +x bin/iris bin/iris-onboard
@@ -96,6 +107,11 @@ COPY deploy/docker/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 # Extension plugins (lark, telegram, weixin, etc.)
 COPY extensions/ extensions/
+# Link @iris/extension-utils — tsc preserves the tsconfig path alias verbatim
+# in emitted JS, so Node.js needs the package resolvable in node_modules.
+# dist/packages/extension-utils/ contains the compiled JS from the build stage.
+RUN mkdir -p node_modules/@iris && \
+    ln -sf /app/dist/packages/extension-utils node_modules/@iris/extension-utils
 RUN mkdir -p /data && chown node:node /data
 
 ENV NODE_ENV=production \
@@ -133,6 +149,9 @@ RUN chmod +x bin/iris bin/iris-onboard
 COPY deploy/docker/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 COPY extensions/ extensions/
+# Link @iris/extension-utils (same as production stage)
+RUN mkdir -p node_modules/@iris && \
+    ln -sf /app/dist/packages/extension-utils node_modules/@iris/extension-utils
 
 RUN mkdir -p /data && chown 1001:1001 /data
 

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -43,5 +43,5 @@ fi
 if echo "$IRIS_PLATFORM" | grep -qw "console"; then
   exec /app/bin/iris "$@"
 else
-  exec node dist/index.js "$@"
+  exec node dist/src/index.js "$@"
 fi

--- a/deploy/docker/fix-esm-imports.cjs
+++ b/deploy/docker/fix-esm-imports.cjs
@@ -1,0 +1,68 @@
+// fix-esm-imports.cjs
+//
+// Post-tsc fixup for Node.js ESM compatibility.
+//
+// Problem: tsconfig uses moduleResolution "bundler", so tsc emits bare
+// specifiers (e.g. `from './bootstrap'`, `from '@iris/extension-utils'`)
+// that only resolve under a bundler runtime (tsx / bun). Plain `node`
+// with "type": "module" requires:
+//   1. Explicit `.js` extensions on relative imports
+//   2. Directory imports to include `/index.js`
+//
+// This script walks the compiled `dist/` tree and rewrites imports to
+// satisfy Node.js ESM resolution rules.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const baseDir = process.argv[2] || 'dist';
+let fixCount = 0;
+
+function walkDir(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkDir(full);
+    else if (entry.name.endsWith('.js')) fixFile(full);
+  }
+}
+
+function fixFile(filePath) {
+  let code = fs.readFileSync(filePath, 'utf8');
+  let changed = false;
+
+  code = code.replace(
+    /((?:from|import)\s*\(?['"])(\.[^'"]+)(['"])/g,
+    (match, pre, importPath, post) => {
+      if (/\.(js|json|mjs|cjs)$/.test(importPath)) return match;
+
+      const resolved = path.resolve(path.dirname(filePath), importPath);
+
+      // Directory import → append /index.js
+      if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+        if (fs.existsSync(path.join(resolved, 'index.js'))) {
+          changed = true;
+          return pre + importPath + '/index.js' + post;
+        }
+      }
+
+      // Extensionless import → append .js
+      if (fs.existsSync(resolved + '.js')) {
+        changed = true;
+        return pre + importPath + '.js' + post;
+      }
+
+      return match;
+    }
+  );
+
+  if (changed) {
+    fs.writeFileSync(filePath, code);
+    fixCount++;
+  }
+}
+
+console.log('[fix-esm-imports] Rewriting imports in', baseDir);
+walkDir(baseDir);
+console.log('[fix-esm-imports] Done.', fixCount, 'files rewritten.');

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "ws": "^8.18.0",
     "xlsx": "^0.18.5",
     "yaml": "^2.8.2",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@iris/extension-utils": "file:packages/extension-utils"
   },
   "optionalDependencies": {
     "@opentui/core": "^0.1.88",
@@ -52,7 +53,6 @@
   },
   "devDependencies": {
     "@irises/extension-sdk": "file:packages/extension-sdk",
-    "@iris/extension-utils": "file:packages/extension-utils",
     "@types/better-sqlite3": "^7.6.13",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^22.19.15",


### PR DESCRIPTION
## Summary

Fix three bugs (plus a resulting path issue) that prevent the Docker image from running under plain `node` (Node.js ESM):

- **Stale directory reference**: `COPY onboard/ onboard/` fails because the directory was renamed to `terminal/` in cb016a3
- **ESM import resolution**: `tsc` with `moduleResolution: "bundler"` emits bare specifiers (no `.js` extension, no `/index.js` for directories). Plain Node.js ESM rejects these with `ERR_UNSUPPORTED_DIR_IMPORT` / `ERR_MODULE_NOT_FOUND`. Added a post-build script (`fix-esm-imports.cjs`) to rewrite imports.
- **Missing `@iris/extension-utils` at runtime**: tsconfig `paths` are compile-time only, the package was a devDependency (pruned by `npm prune`), and `packages/` was never copied into the build stage. Moved to `dependencies`, copy `packages/` for tsc, generate a Node-compatible `package.json`, and symlink into `node_modules`.
- **Entrypoint path**: Adding `packages/` causes tsc to infer `rootDir` as `.`, so entry point moves from `dist/index.js` to `dist/src/index.js`.

## Changed files

| File | Change |
|------|--------|
| `deploy/docker/Dockerfile` | Fix stale `onboard/` path, add ESM fixup step, add `@iris/extension-utils` linking for both production and computer-use stages |
| `deploy/docker/fix-esm-imports.cjs` | New post-tsc script that adds `.js` extensions and `/index.js` suffixes to ESM imports |
| `deploy/docker/entrypoint.sh` | Fix entry point path: `dist/index.js` → `dist/src/index.js` |
| `package.json` | Move `@iris/extension-utils` from `devDependencies` to `dependencies` (needed at runtime) |

## Reproduction

The current `main` branch Docker image crashes immediately on startup:

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import .../dist/utils
is not supported resolving ES modules
```

The pre-built GHCR image (`ghcr.io/lianues/iris:latest`) has the same issue.

## Test plan

- [x] `docker build -t iris .` completes successfully
- [x] Container starts and serves the web UI on port 8192
- [x] Tested on Ubuntu 24.04 LTS, Node.js 22, Docker 27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
