### PR TITLE
fix(run): 仅在 console 平台时强制使用 Bun 运行时

### DIFF
--- a/script/run.ts
+++ b/script/run.ts
@@ -83,10 +83,15 @@ async function main() {
   const config = loadConfig()
   const packageManager = detectPackageManager()
   const hasConsolePlatform = config.platform.types.includes('console')
-  const preferBunRuntime = packageManager === 'bun'
 
-  if (preferBunRuntime || hasConsolePlatform) {
-    if (hasConsolePlatform && !preferBunRuntime) {
+  // 只有在配置了 console 平台时才必须使用 Bun 运行时。
+  // 即使通过 bun start 启动，如果没有 console 平台，也应回退到 Node.js + tsx，
+  // 因为项目依赖 better-sqlite3 等原生模块，Bun 尚不支持。
+  // 参见: https://github.com/oven-sh/bun/issues/4290
+  const preferBunRuntime = hasConsolePlatform
+
+  if (preferBunRuntime) {
+    if (packageManager !== 'bun') {
       console.log('[Iris] 检测到 console 平台，已自动切换到 Bun 运行时。')
     }
 


### PR DESCRIPTION
## 问题

之前 `script/run.ts` 的运行时选择逻辑为：只要通过 `bun start` 启动，就走 Bun 运行时。即使用户没有配置 console 平台（只用 web、telegram 等），也会被迫使用 Bun 运行，导致 `better-sqlite3` 等原生模块报错。

## 修改

将 `preferBunRuntime` 的判断条件从 `packageManager === 'bun'` 改为 `hasConsolePlatform`：

- **配了 console 平台** → 强制使用 Bun 运行时（`@opentui` 依赖 Bun API）
- **没配 console 平台** → 一律走 Node.js + tsx，无论用户用哪个包管理器启动

打包产物不受影响，因为 `bun build --compile` 已将 Bun 运行时内嵌到二进制文件中。

## 参考

- https://github.com/oven-sh/bun/issues/4290