### PR TITLE
fix: Docker build — stale path, ESM resolution, missing runtime package

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY package.json package-lock.json ./
+COPY packages/extension-sdk/package.json packages/extension-sdk/package.json
 # Prepare web-ui directory for its own package.json
 RUN mkdir -p src/platforms/web/web-ui
 COPY src/platforms/web/web-ui/package.json src/platforms/web/web-ui/
@@ -40,9 +41,12 @@ RUN cd src/platforms/web/web-ui && npm run build
 FROM deps AS build
 COPY src/ src/
 COPY tsconfig.json tsconfig.build.json ./
+COPY packages/ packages/
 COPY data/ data/
 # Overlay pre-built web-ui into source tree
 COPY --from=build-ui /app/src/platforms/web/web-ui/dist/ src/platforms/web/web-ui/dist/
+# Build extension-sdk (needed at runtime by core imports)
+RUN cd packages/extension-sdk && npx tsc
 RUN npx tsc -p tsconfig.build.json
 # Strip devDependencies — production image only needs runtime deps
 RUN npm prune --omit=dev
@@ -58,9 +62,10 @@ RUN npm install --no-save react-devtools-core
 
 COPY src/ src/
 COPY tsconfig.json tsconfig.build.json ./
+COPY packages/ packages/
 COPY data/ data/
 COPY script/build.ts script/build.ts
-COPY onboard/ onboard/
+COPY terminal/ terminal/
 # Overlay pre-built web-ui
 COPY --from=build-ui /app/src/platforms/web/web-ui/dist/ src/platforms/web/web-ui/dist/
 
@@ -83,6 +88,8 @@ COPY --from=build /app/dist/ dist/
 # Runtime dependencies only (devDeps pruned in build stage)
 COPY --from=build /app/node_modules/ node_modules/
 COPY --from=build /app/package.json .
+# Extension SDK (symlinked from node_modules)
+COPY --from=build /app/packages/extension-sdk/ packages/extension-sdk/
 # Config templates for first-run init
 COPY --from=build /app/data/ data/
 # Web UI static files — resolvePublicDir() checks cwd/src/platforms/web/web-ui/dist
@@ -93,6 +100,7 @@ COPY --from=bun-compile /app/dist/bin/iris-linux-x64/bin/iris-onboard bin/iris-o
 RUN chmod +x bin/iris bin/iris-onboard
 # Entrypoint script
 COPY deploy/docker/entrypoint.sh /app/entrypoint.sh
+COPY deploy/docker/esm-fix.mjs /app/esm-fix.mjs
 RUN chmod +x /app/entrypoint.sh
 # Extension plugins (lark, telegram, weixin, etc.)
 COPY extensions/ extensions/
@@ -125,12 +133,15 @@ WORKDIR /app
 COPY --from=build /app/dist/ dist/
 COPY --from=build /app/node_modules/ node_modules/
 COPY --from=build /app/package.json .
+# Extension SDK (symlinked from node_modules)
+COPY --from=build /app/packages/extension-sdk/ packages/extension-sdk/
 COPY --from=build /app/data/ data/
 COPY --from=build-ui /app/src/platforms/web/web-ui/dist/ src/platforms/web/web-ui/dist/
 COPY --from=bun-compile /app/dist/bin/iris-linux-x64/bin/iris bin/iris
 COPY --from=bun-compile /app/dist/bin/iris-linux-x64/bin/iris-onboard bin/iris-onboard
 RUN chmod +x bin/iris bin/iris-onboard
 COPY deploy/docker/entrypoint.sh /app/entrypoint.sh
+COPY deploy/docker/esm-fix.mjs /app/esm-fix.mjs
 RUN chmod +x /app/entrypoint.sh
 COPY extensions/ extensions/
 

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -43,5 +43,5 @@ fi
 if echo "$IRIS_PLATFORM" | grep -qw "console"; then
   exec /app/bin/iris "$@"
 else
-  exec node dist/index.js "$@"
+  exec node --import ./esm-fix.mjs dist/index.js "$@"
 fi

--- a/deploy/docker/esm-fix.mjs
+++ b/deploy/docker/esm-fix.mjs
@@ -1,0 +1,14 @@
+// Bridges tsc (moduleResolution: "bundler") output with Node.js ESM resolution.
+// tsc emits extensionless relative specifiers; Node.js ESM requires explicit .js.
+import { register } from 'node:module';
+
+register(`data:text/javascript,${encodeURIComponent(`
+export async function resolve(specifier, context, nextResolve) {
+  if (!specifier.startsWith('.') || /\.\w+$/.test(specifier))
+    return nextResolve(specifier, context);
+  for (const suffix of ['.js', '/index.js']) {
+    try { return await nextResolve(specifier + suffix, context); } catch {}
+  }
+  return nextResolve(specifier, context);
+}
+`)}`);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "ws": "^8.18.0",
     "xlsx": "^0.18.5",
     "yaml": "^2.8.2",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@irises/extension-sdk": "file:packages/extension-sdk"
   },
   "optionalDependencies": {
     "@opentui/core": "^0.1.88",
@@ -51,7 +52,6 @@
     "libreoffice-convert": "^1.8.1"
   },
   "devDependencies": {
-    "@irises/extension-sdk": "file:packages/extension-sdk",
     "@types/better-sqlite3": "^7.6.13",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^22.19.15",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "allowImportingTsExtensions": false
+    "allowImportingTsExtensions": false,
+    "rootDir": "src"
   },
   "exclude": ["node_modules", "dist", "extensions", "src/platforms/web/web-ui", "src/platforms/console"]
 }


### PR DESCRIPTION
## 问题

当前 main 分支的 Docker 镜像无法构建/运行，存在三个独立问题：

1. **`onboard/` 目录不存在** — 已重命名为 `terminal/`，Dockerfile Stage 4 的 `COPY onboard/` 构建失败
2. **Node.js ESM 解析失败** — `tsc` 使用 `moduleResolution: "bundler"` 编译输出的 import 没有 `.js` 扩展名，`node dist/index.js` 启动时报 `ERR_MODULE_NOT_FOUND`
3. **`@irises/extension-sdk` 运行时缺失** — 核心代码（23 个文件）在运行时 import 该包，但它是 devDependency，被 `npm prune --omit=dev` 移除了

## 修复

| 文件 | 改动 |
|------|------|
| `deploy/docker/Dockerfile` | `onboard/` → `terminal/`；添加 `packages/` COPY 和 extension-sdk 构建步骤；添加 `esm-fix.mjs` COPY |
| `deploy/docker/entrypoint.sh` | `node` → `node --import ./esm-fix.mjs`（注册 ESM resolve hook） |
| `deploy/docker/esm-fix.mjs` | 新增 14 行 ESM loader，用 Node.js 稳定 API `module.register()` 为无扩展名的相对导入补 `.js`/`/index.js` |
| `package.json` | `@irises/extension-sdk` 从 devDependencies 移到 dependencies |
| `tsconfig.build.json` | 显式设置 `rootDir: "src"` 防止 `COPY packages/` 导致输出路径漂移 |

## 验证

```bash
docker build -t iris -f deploy/docker/Dockerfile .
docker run --rm iris
```