### PR TITLE
fix(core): IrisAPI 属性名与 extension-sdk 类型声明不匹配

### DIFF
--- a/src/core/iris-core.ts
+++ b/src/core/iris-core.ts
@@ -601,8 +601,8 @@ export class IrisCore {
         };
         return new ToolLoop(loopOptions.tools as ToolRegistry, loopPrompt, loopConfig);
       },
-      registerRoute,
-      registerPanel,
+      registerWebRoute: registerRoute,
+      registerWebPanel: registerPanel,
       agentNetwork: options.agentNetwork,
       registerConsoleSettingsTab,
       getConsoleSettingsTabs: () => consoleSettingsTabs,


### PR DESCRIPTION
## 问题

`iris-core.ts` 构建 IrisAPI 对象时使用了 JS shorthand property 语法：

```ts
registerRoute,
registerPanel,
```

这导致对象属性名为 `registerRoute` / `registerPanel`，但 `extension-sdk` 中的 `IrisAPI` 接口声明为 `registerWebRoute` / `registerWebPanel`。

由于这两个方法标记为 `optional (?)`，TypeScript 编译期不报错。运行时扩展调用 `api.registerWebRoute()` 得到 `undefined`，所有扩展的 Web 路由和面板**静默注册失败**。

## 影响范围

所有使用 `registerWebRoute` / `registerWebPanel` 的扩展：

- `extensions/server-ops`（运维面板）
- `extensions/computer-use`（浏览器控制）
- `extensions/cron`（定时任务管理）

## 修复

将 shorthand property 改为显式映射，使属性名匹配 SDK 类型声明：

```diff
-      registerRoute,
-      registerPanel,
+      registerWebRoute: registerRoute,
+      registerWebPanel: registerPanel,
```

## 测试要点

- [ ] 启动 Iris，确认 server-ops 日志输出 `Web 路由和面板已注册`
- [ ] 访问 `/api/plugins/server-ops/panel` 确认 Dashboard 正常渲染
- [ ] 确认 cron、computer-use 扩展的 Web 路由同样正常注册