### PR TITLE
fix(telegram): 修复 /stop 无法中止长回合的问题

### DIFF
--- a/extensions/telegram/dist/index.mjs
+++ b/extensions/telegram/dist/index.mjs
@@ -11812,13 +11812,15 @@ ${list}`);
         }
       }
       const sessionId = cs.sessionId;
+      const turnTrace = cs.turnTrace;
       this.backend.chat(sessionId, message.text, images, documents, "telegram").catch((err) => {
         logger5.error(`Telegram 回合执行失败 (session=${sessionId}):`, err);
+        if (cs.sessionId !== sessionId || cs.turnTrace !== turnTrace)
+          return;
         this.stopTypingIndicator(cs);
         this.cleanupStream(cs);
         cs.turnTrace = null;
         cs.busy = false;
-        cs.stopped = false;
       });
     } catch (err) {
       logger5.error(`Telegram 回合分发失败 (session=${cs.sessionId}):`, err);

--- a/extensions/telegram/dist/index.mjs
+++ b/extensions/telegram/dist/index.mjs
@@ -10728,6 +10728,7 @@ var TYPING_REFRESH_MS = 4000;
 var UNSUPPORTED_MEDIA_NOTICE = "当前阶段暂不支持直接处理图片、文件或语音消息，请附带文字说明后再次发送。";
 var BUFFERED_NOTICE = `\uD83D\uDCE5 消息已暂存，等 AI 回复结束后自动发送。
 发送 /flush 可立即处理，/stop 可中止当前回复。`;
+var BUSY_COMMAND_NOTICE = "ℹ️ 当前正在回复中，请先 /stop。";
 var MESSAGE_DEDUP_MAX_SIZE = 500;
 var MESSAGE_EXPIRE_MS = 30000;
 var DEDUP_CLEANUP_INTERVAL_MS = 60000;
@@ -11389,11 +11390,12 @@ ${content}`;
       const parsed = this.messageHandler.parseIncomingText(ctx);
       if (!parsed)
         return;
-      if (this.messageDedup.has(parsed.messageId)) {
-        logger5.debug(`跳过重复消息: message_id=${parsed.messageId}`);
+      const dedupKey = `${parsed.session.chatKey}:${parsed.messageId}`;
+      if (this.messageDedup.has(dedupKey)) {
+        logger5.debug(`跳过重复消息: ${dedupKey}`);
         return;
       }
-      this.messageDedup.add(parsed.messageId);
+      this.messageDedup.add(dedupKey);
       this.cleanupDedupIfNeeded();
       const messageDate = typeof ctx.message?.date === "number" ? ctx.message.date * 1000 : 0;
       if (messageDate > 0) {
@@ -11474,36 +11476,41 @@ ${content}`;
         return;
       const command = data.substring(0, colonIdx);
       const arg = data.substring(colonIdx + 1);
+      const activeCs = this.chatStates.get(target.chatKey);
       let resultText = "";
-      switch (command) {
-        case "model": {
-          try {
-            const result = this.backend.switchModel(arg, "telegram");
-            resultText = `✅ 模型已切换为 ${result.modelName} → ${result.modelId}`;
-          } catch {
-            resultText = `❌ 未找到模型 "${arg}"。`;
+      if (activeCs?.busy) {
+        resultText = BUSY_COMMAND_NOTICE;
+      } else {
+        switch (command) {
+          case "model": {
+            try {
+              const result = this.backend.switchModel(arg, "telegram");
+              resultText = `✅ 模型已切换为 ${result.modelName} → ${result.modelId}`;
+            } catch {
+              resultText = `❌ 未找到模型 "${arg}"。`;
+            }
+            break;
           }
-          break;
-        }
-        case "session": {
-          const index = parseInt(arg, 10);
-          const metas = await this.backend.listSessionMetas();
-          if (isNaN(index) || index < 1 || index > metas.length) {
-            resultText = `❌ 会话编号无效。`;
-          } else {
-            const meta = metas[index - 1];
-            this.activeSessions.set(target.chatKey, meta.id);
-            resultText = `✅ 已切换到会话：${meta.title || "(无标题)"}`;
+          case "session": {
+            const index = parseInt(arg, 10);
+            const metas = await this.backend.listSessionMetas();
+            if (isNaN(index) || index < 1 || index > metas.length) {
+              resultText = `❌ 会话编号无效。`;
+            } else {
+              const meta = metas[index - 1];
+              this.activeSessions.set(target.chatKey, meta.id);
+              resultText = `✅ 已切换到会话：${meta.title || "(无标题)"}`;
+            }
+            break;
           }
-          break;
+          case "mode": {
+            const ok = this.backend.switchMode?.(arg);
+            resultText = ok ? `✅ 已切换到 Mode "${arg}"。` : `❌ 未找到 Mode "${arg}"。`;
+            break;
+          }
+          default:
+            resultText = `❌ 未知操作: ${command}`;
         }
-        case "mode": {
-          const ok = this.backend.switchMode?.(arg);
-          resultText = ok ? `✅ 已切换到 Mode "${arg}"。` : `❌ 未找到 Mode "${arg}"。`;
-          break;
-        }
-        default:
-          resultText = `❌ 未知操作: ${command}`;
       }
       await this.client.editText(target, messageId, resultText);
       await this.client.answerCallbackQuery(callbackQueryId);
@@ -11516,6 +11523,10 @@ ${content}`;
     if (!cmd)
       return false;
     const reply = (content) => this.sendToChat(cs, content, { trackMessage: false });
+    if (cs.busy && cmd.name !== "stop" && cmd.name !== "flush" && cmd.name !== "help") {
+      await reply(BUSY_COMMAND_NOTICE);
+      return true;
+    }
     switch (cmd.name) {
       case "new": {
         const newSid = `telegram-${cs.target.chatKey.replace(/:/g, "-")}-${Date.now()}`;
@@ -11586,6 +11597,7 @@ ${content}`;
           await reply("ℹ️ 当前没有正在进行的回复。");
           return true;
         }
+        cs.pendingMessages.splice(0);
         cs.stopped = true;
         this.stopTypingIndicator(cs);
         this.backend.abortChat(cs.sessionId);
@@ -11616,10 +11628,6 @@ ${content}`;
         return true;
       }
       case "undo": {
-        if (cs.busy) {
-          await reply("ℹ️ 当前正在回复中，请先 /stop。");
-          return true;
-        }
         if (typeof this.backend.undo !== "function") {
           await reply("❌ 当前宿主未提供撤销能力。");
           return true;
@@ -11633,10 +11641,6 @@ ${content}`;
         return true;
       }
       case "redo": {
-        if (cs.busy) {
-          await reply("ℹ️ 当前正在回复中，请先 /stop。");
-          return true;
-        }
         if (typeof this.backend.redo !== "function") {
           await reply("❌ 当前宿主未提供恢复能力。");
           return true;
@@ -11807,7 +11811,15 @@ ${list}`);
             documents = [...documents || [], voice];
         }
       }
-      await this.backend.chat(cs.sessionId, message.text, images, documents, "telegram");
+      const sessionId = cs.sessionId;
+      this.backend.chat(sessionId, message.text, images, documents, "telegram").catch((err) => {
+        logger5.error(`Telegram 回合执行失败 (session=${sessionId}):`, err);
+        this.stopTypingIndicator(cs);
+        this.cleanupStream(cs);
+        cs.turnTrace = null;
+        cs.busy = false;
+        cs.stopped = false;
+      });
     } catch (err) {
       logger5.error(`Telegram 回合分发失败 (session=${cs.sessionId}):`, err);
       this.stopTypingIndicator(cs);

--- a/extensions/telegram/src/index.ts
+++ b/extensions/telegram/src/index.ts
@@ -1423,15 +1423,16 @@ export class TelegramPlatform extends PlatformAdapter {
       }
 
       const sessionId = cs.sessionId;
+      const turnTrace = cs.turnTrace;
       // grammY 的 simple long polling 会等待 middleware resolve；这里不能 await 整个 Backend turn，
       // 否则后续 /stop update 进不了 handler。最终回复和清理由 response/error/done 事件收口。
       void this.backend.chat(sessionId, message.text, images, documents, 'telegram').catch((err) => {
         logger.error(`Telegram 回合执行失败 (session=${sessionId}):`, err);
+        if (cs.sessionId !== sessionId || cs.turnTrace !== turnTrace) return;
         this.stopTypingIndicator(cs);
         this.cleanupStream(cs);
         cs.turnTrace = null;
         cs.busy = false;
-        cs.stopped = false;
       });
     } catch (err) {
       logger.error(`Telegram 回合分发失败 (session=${cs.sessionId}):`, err);

--- a/extensions/telegram/src/index.ts
+++ b/extensions/telegram/src/index.ts
@@ -54,6 +54,7 @@ const TYPING_REFRESH_MS = 4_000;
 
 const UNSUPPORTED_MEDIA_NOTICE = '当前阶段暂不支持直接处理图片、文件或语音消息，请附带文字说明后再次发送。';
 const BUFFERED_NOTICE = '📥 消息已暂存，等 AI 回复结束后自动发送。\n发送 /flush 可立即处理，/stop 可中止当前回复。';
+const BUSY_COMMAND_NOTICE = 'ℹ️ 当前正在回复中，请先 /stop。';
 
 // ---- Phase 7：健壮性常量 ----
 
@@ -134,8 +135,8 @@ export class TelegramPlatform extends PlatformAdapter {
   private readonly chatStates = new Map<string, TelegramChatState>();
   /** chatKey → sessionId 映射，/new 时更新 */
   private readonly activeSessions = new Map<string, string>();
-  /** Phase 7：消息去重集合（update_id 或 message_id）。避免重复处理同一条消息。 */
-  private readonly messageDedup = new Set<number>();
+  /** Phase 7：消息去重集合（chatKey + message_id）。避免重复处理同一条消息。 */
+  private readonly messageDedup = new Set<string>();
   /** Phase 7：去重集合上次清理时间 */
   private lastDedupCleanup = Date.now();
   private backendListenersReady = false;
@@ -916,11 +917,13 @@ export class TelegramPlatform extends PlatformAdapter {
 
       // ---- Phase 7：消息去重 ----
       // 目的：避免 bot 重启或网络抖动导致重复处理同一条消息。
-      if (this.messageDedup.has(parsed.messageId)) {
-        logger.debug(`跳过重复消息: message_id=${parsed.messageId}`);
+      // Telegram 的 message_id 只在单个 chat 内唯一，必须带上 chatKey 才能避免跨私聊/群聊误去重。
+      const dedupKey = `${parsed.session.chatKey}:${parsed.messageId}`;
+      if (this.messageDedup.has(dedupKey)) {
+        logger.debug(`跳过重复消息: ${dedupKey}`);
         return;
       }
-      this.messageDedup.add(parsed.messageId);
+      this.messageDedup.add(dedupKey);
       this.cleanupDedupIfNeeded();
 
       // ---- Phase 7：消息过期检测 ----
@@ -981,7 +984,7 @@ export class TelegramPlatform extends PlatformAdapter {
         metadata: { sessionId: parsed.session.sessionId },
       });
 
-      // 命令处理（任何时候都能用，不受 busy 影响）
+      // 命令优先处理；busy 时 handleCommand 只放行不改变 turn 身份的安全命令。
       if (parsed.text.startsWith('/')) {
         const handled = await this.handleCommand(parsed.text, cs);
         if (handled) return;
@@ -1029,40 +1032,47 @@ export class TelegramPlatform extends PlatformAdapter {
       const command = data.substring(0, colonIdx);
       const arg = data.substring(colonIdx + 1);
 
+      const activeCs = this.chatStates.get(target.chatKey);
       let resultText = '';
 
-      switch (command) {
-        case 'model': {
-          try {
-            const result = this.backend.switchModel(arg, 'telegram');
-            resultText = `✅ 模型已切换为 ${result.modelName} → ${result.modelId}`;
-          } catch {
-            resultText = `❌ 未找到模型 "${arg}"。`;
+      if (activeCs?.busy) {
+        // Inline keyboard 可能来自旧菜单；busy 期间不允许按钮切换 session/model/mode，
+        // 否则当前 turn 的 response/done 将无法再按原 sessionId 精确收口。
+        resultText = BUSY_COMMAND_NOTICE;
+      } else {
+        switch (command) {
+          case 'model': {
+            try {
+              const result = this.backend.switchModel(arg, 'telegram');
+              resultText = `✅ 模型已切换为 ${result.modelName} → ${result.modelId}`;
+            } catch {
+              resultText = `❌ 未找到模型 "${arg}"。`;
+            }
+            break;
           }
-          break;
-        }
 
-        case 'session': {
-          const index = parseInt(arg, 10);
-          const metas = await this.backend.listSessionMetas();
-          if (isNaN(index) || index < 1 || index > metas.length) {
-            resultText = `❌ 会话编号无效。`;
-          } else {
-            const meta = metas[index - 1];
-            this.activeSessions.set(target.chatKey, meta.id);
-            resultText = `✅ 已切换到会话：${meta.title || '(无标题)'}`;
+          case 'session': {
+            const index = parseInt(arg, 10);
+            const metas = await this.backend.listSessionMetas();
+            if (isNaN(index) || index < 1 || index > metas.length) {
+              resultText = `❌ 会话编号无效。`;
+            } else {
+              const meta = metas[index - 1];
+              this.activeSessions.set(target.chatKey, meta.id);
+              resultText = `✅ 已切换到会话：${meta.title || '(无标题)'}`;
+            }
+            break;
           }
-          break;
-        }
 
-        case 'mode': {
-          const ok = this.backend.switchMode?.(arg);
-          resultText = ok ? `✅ 已切换到 Mode "${arg}"。` : `❌ 未找到 Mode "${arg}"。`;
-          break;
-        }
+          case 'mode': {
+            const ok = this.backend.switchMode?.(arg);
+            resultText = ok ? `✅ 已切换到 Mode "${arg}"。` : `❌ 未找到 Mode "${arg}"。`;
+            break;
+          }
 
-        default:
-          resultText = `❌ 未知操作: ${command}`;
+          default:
+            resultText = `❌ 未知操作: ${command}`;
+        }
       }
 
       // 编辑原消息为结果文本（去掉 inline keyboard）
@@ -1081,6 +1091,11 @@ export class TelegramPlatform extends PlatformAdapter {
     if (!cmd) return false;
 
     const reply = (content: string) => this.sendToChat(cs, content, { trackMessage: false });
+    if (cs.busy && cmd.name !== 'stop' && cmd.name !== 'flush' && cmd.name !== 'help') {
+      // Telegram 现在会在长回合中继续接收命令；busy 期间只放行不会改变 turn 身份的命令。
+      await reply(BUSY_COMMAND_NOTICE);
+      return true;
+    }
 
     switch (cmd.name) {
       case 'new': {
@@ -1165,6 +1180,8 @@ export class TelegramPlatform extends PlatformAdapter {
           await reply('ℹ️ 当前没有正在进行的回复。');
           return true;
         }
+        // /stop 的语义是“停下并丢弃已缓冲输入”；/flush 才负责“停下并继续处理缓冲”。
+        cs.pendingMessages.splice(0);
         cs.stopped = true;
         this.stopTypingIndicator(cs);
         this.backend.abortChat(cs.sessionId);
@@ -1198,10 +1215,6 @@ export class TelegramPlatform extends PlatformAdapter {
       }
 
       case 'undo': {
-        if (cs.busy) {
-          await reply('ℹ️ 当前正在回复中，请先 /stop。');
-          return true;
-        }
         if (typeof this.backend.undo !== 'function') {
           await reply('❌ 当前宿主未提供撤销能力。');
           return true;
@@ -1219,10 +1232,6 @@ export class TelegramPlatform extends PlatformAdapter {
       }
 
       case 'redo': {
-        if (cs.busy) {
-          await reply('ℹ️ 当前正在回复中，请先 /stop。');
-          return true;
-        }
         if (typeof this.backend.redo !== 'function') {
           await reply('❌ 当前宿主未提供恢复能力。');
           return true;
@@ -1413,7 +1422,17 @@ export class TelegramPlatform extends PlatformAdapter {
         }
       }
 
-      await this.backend.chat(cs.sessionId, message.text, images, documents, 'telegram');
+      const sessionId = cs.sessionId;
+      // grammY 的 simple long polling 会等待 middleware resolve；这里不能 await 整个 Backend turn，
+      // 否则后续 /stop update 进不了 handler。最终回复和清理由 response/error/done 事件收口。
+      void this.backend.chat(sessionId, message.text, images, documents, 'telegram').catch((err) => {
+        logger.error(`Telegram 回合执行失败 (session=${sessionId}):`, err);
+        this.stopTypingIndicator(cs);
+        this.cleanupStream(cs);
+        cs.turnTrace = null;
+        cs.busy = false;
+        cs.stopped = false;
+      });
     } catch (err) {
       logger.error(`Telegram 回合分发失败 (session=${cs.sessionId}):`, err);
       this.stopTypingIndicator(cs);

--- a/tests/robustness-phase7.test.ts
+++ b/tests/robustness-phase7.test.ts
@@ -181,6 +181,35 @@ describe('Telegram Phase 7: 消息去重', () => {
     await (platform as any).handleMessage(makeCtx(101, '第二次'));
     expect(backend.chats).toHaveLength(2);
   });
+
+  it('相同 message_id 在不同聊天中互不影响', async () => {
+    // Telegram message_id 是 chat-local；跨聊天复用相同数字不应被全局去重吞掉。
+    const { TelegramPlatform } = await import('../extensions/telegram/src');
+
+    class FakeBackend extends EventEmitter {
+      chats: any[] = [];
+      async chat(sid: string, text: string) { this.chats.push({ sid, text }); }
+      isStreamEnabled() { return false; }
+    }
+
+    const backend = new FakeBackend();
+    const platform = new TelegramPlatform(backend as any, {
+      token: 'bot-token',
+      groupMentionRequired: false,
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    const makeCtx = (chatId: number, text: string) => ({
+      chat: { id: chatId, type: 'private' },
+      me: { username: 'test_bot' },
+      message: { message_id: 100, text, date: now },
+    });
+
+    await (platform as any).handleMessage(makeCtx(3003, '第一位用户'));
+    await (platform as any).handleMessage(makeCtx(3004, '第二位用户'));
+
+    expect(backend.chats.map((chat) => chat.text)).toEqual(['第一位用户', '第二位用户']);
+  });
 });
 
 describe('Telegram Phase 7: 消息过期', () => {

--- a/tests/telegram-phase1-platform.test.ts
+++ b/tests/telegram-phase1-platform.test.ts
@@ -12,6 +12,7 @@ import { TelegramPlatform } from '../extensions/telegram/src';
 
 class FakeBackend extends EventEmitter {
   chats: Array<{ sessionId: string; text: string; images?: any[]; documents?: any[] }> = [];
+  abortChat = vi.fn();
 
   async chat(sessionId: string, text: string, images?: any[], documents?: any[]): Promise<void> {
     this.chats.push({ sessionId, text, images, documents });
@@ -23,6 +24,73 @@ class FakeBackend extends EventEmitter {
 }
 
 describe('Telegram Phase 1.3: platform concurrency', () => {
+  it('/stop 在长回合中可进入，并中止当前 turn 而不是继续处理缓冲消息', async () => {
+    class SlowBackend extends FakeBackend {
+      private readonly resolvers: Array<() => void> = [];
+
+      override chat(sessionId: string, text: string, images?: any[], documents?: any[]): Promise<void> {
+        this.chats.push({ sessionId, text, images, documents });
+        return new Promise((resolve) => {
+          this.resolvers.push(resolve);
+        });
+      }
+
+      resolveNext(): void {
+        this.resolvers.shift()?.();
+      }
+    }
+
+    const backend = new SlowBackend();
+    const platform = new TelegramPlatform(backend as any, {
+      token: 'bot-token',
+      groupMentionRequired: false,
+      outputFormat: 'plain',
+    });
+    (platform as any).setupBackendListeners();
+
+    const sentMessages: string[] = [];
+    (platform as any).client = {
+      sendMessageReturningId: vi.fn(async (_target: unknown, text: string) => {
+        sentMessages.push(text);
+        return 999;
+      }),
+      sendTextReturningIds: vi.fn(async (_target: unknown, text: string) => {
+        sentMessages.push(text);
+        return [999];
+      }),
+      sendTyping: vi.fn(async () => undefined),
+    };
+
+    const makeCtx = (messageId: number, text: string) => ({
+      chat: { id: 1003, type: 'private' },
+      me: { username: 'iris_bot' },
+      message: { message_id: messageId, text },
+    });
+
+    // 旧实现会一直 await backend.chat()，导致这一 Promise 在长回合结束前不 resolve。
+    // 现在 handler 必须尽快返回，后续 /stop 才能被 grammY 投递进来。
+    const firstTurn = (platform as any).handleMessage(makeCtx(10, '长回合'));
+    const firstResult = await Promise.race([
+      firstTurn.then(() => 'resolved'),
+      new Promise((resolve) => setTimeout(() => resolve('timeout'), 25)),
+    ]);
+    expect(firstResult).toBe('resolved');
+    expect(backend.chats).toHaveLength(1);
+
+    await (platform as any).handleMessage(makeCtx(11, '第二条'));
+    expect(sentMessages.some((m) => m.includes('暂存'))).toBe(true);
+
+    await (platform as any).handleMessage(makeCtx(12, '/stop'));
+    expect(backend.abortChat).toHaveBeenCalledWith(backend.chats[0].sessionId);
+
+    // /stop 会丢弃已暂存输入；done 后不应再自动 flush 第二条消息。
+    backend.resolveNext();
+    backend.emit('done', backend.chats[0].sessionId);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(backend.chats).toHaveLength(1);
+  });
+
   it('在 busy 时暂存消息，并在 done 后自动继续处理', async () => {
     const backend = new FakeBackend();
     const platform = new TelegramPlatform(backend as any, {

--- a/tests/telegram-phase1-platform.test.ts
+++ b/tests/telegram-phase1-platform.test.ts
@@ -69,12 +69,12 @@ describe('Telegram Phase 1.3: platform concurrency', () => {
 
     // 旧实现会一直 await backend.chat()，导致这一 Promise 在长回合结束前不 resolve。
     // 现在 handler 必须尽快返回，后续 /stop 才能被 grammY 投递进来。
-    const firstTurn = (platform as any).handleMessage(makeCtx(10, '长回合'));
-    const firstResult = await Promise.race([
-      firstTurn.then(() => 'resolved'),
-      new Promise((resolve) => setTimeout(() => resolve('timeout'), 25)),
-    ]);
-    expect(firstResult).toBe('resolved');
+    let firstTurnResolved = false;
+    const firstTurn = (platform as any).handleMessage(makeCtx(10, '长回合'))
+      .then(() => { firstTurnResolved = true; });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(firstTurnResolved).toBe(true);
+    await firstTurn;
     expect(backend.chats).toHaveLength(1);
 
     await (platform as any).handleMessage(makeCtx(11, '第二条'));
@@ -89,6 +89,65 @@ describe('Telegram Phase 1.3: platform concurrency', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(backend.chats).toHaveLength(1);
+  });
+
+  it('旧 turn 的异步失败不会清理后续 turn 状态', async () => {
+    class RejectableBackend extends FakeBackend {
+      private readonly rejecters: Array<(err: Error) => void> = [];
+
+      override chat(sessionId: string, text: string, images?: any[], documents?: any[]): Promise<void> {
+        this.chats.push({ sessionId, text, images, documents });
+        return new Promise((_resolve, reject) => {
+          this.rejecters.push(reject);
+        });
+      }
+
+      rejectAt(index: number): void {
+        this.rejecters[index]?.(new Error(`turn ${index} failed`));
+      }
+    }
+
+    const backend = new RejectableBackend();
+    const platform = new TelegramPlatform(backend as any, {
+      token: 'bot-token',
+      groupMentionRequired: false,
+      outputFormat: 'plain',
+    });
+    (platform as any).setupBackendListeners();
+
+    const sentMessages: string[] = [];
+    (platform as any).client = {
+      sendMessageReturningId: vi.fn(async (_target: unknown, text: string) => {
+        sentMessages.push(text);
+        return 999;
+      }),
+      sendTextReturningIds: vi.fn(async (_target: unknown, text: string) => {
+        sentMessages.push(text);
+        return [999];
+      }),
+      sendTyping: vi.fn(async () => undefined),
+    };
+
+    const makeCtx = (messageId: number, text: string) => ({
+      chat: { id: 1004, type: 'private' },
+      me: { username: 'iris_bot' },
+      message: { message_id: messageId, text },
+    });
+
+    await (platform as any).handleMessage(makeCtx(20, '第一轮'));
+    backend.emit('done', backend.chats[0].sessionId);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await (platform as any).handleMessage(makeCtx(21, '第二轮'));
+    expect(backend.chats).toHaveLength(2);
+
+    // 第一轮的 Promise 如果迟到 reject，不应把第二轮 busy 状态清掉。
+    backend.rejectAt(0);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await (platform as any).handleMessage(makeCtx(22, '第三条'));
+    expect(backend.chats).toHaveLength(2);
+    expect(sentMessages.some((m) => m.includes('暂存'))).toBe(true);
   });
 
   it('在 busy 时暂存消息，并在 done 后自动继续处理', async () => {


### PR DESCRIPTION
## 概述

修复 Telegram 私聊/群聊中 `/stop` 无法及时中止当前 Agent 回合的问题。

问题根因是 Telegram 当前使用 grammY 的 simple long polling，middleware 会按 update 顺序等待处理完成。此前 Telegram 平台在分发消息时会 `await backend.chat()`，而 `backend.chat()` 会等到当前 turn 的 `done` 事件后才 resolve，导致后续发送的 `/stop` update 无法进入 handler。

本次调整让 Telegram 平台启动 Backend turn 后立即返回，由既有的 `response` / `error` / `done` 事件继续负责回复投递和状态清理，从而让 `/stop` 能在长回合执行期间被处理。

## 主要更改

- Telegram `dispatchChat` 不再等待完整 Backend turn 完成，避免阻塞后续 `/stop` update。
- busy 期间限制会改变当前 turn 身份或状态的命令，避免 `/new`、`/session`、callback 等在回合中途改变 session/model/mode。
- `/stop` 会清空已暂存消息，和 `/flush` 的“中止后继续处理缓冲消息”语义区分开。
- Telegram 消息去重 key 改为 `chatKey:messageId`，避免不同聊天中相同 `message_id` 被误判为重复消息。
- 增加回归测试覆盖长回合中 `/stop` 可进入、可调用 `abortChat`，以及跨聊天 message_id 去重问题。

## 验证

已运行：

- `npx vitest run tests/telegram-phase1-platform.test.ts tests/robustness-phase7.test.ts`
- `npx vitest run tests/telegram-rich-message.test.ts`
- `npx tsc -p tsconfig.build.json --noEmit`
- `npm --prefix extensions/telegram run build`