### PR TITLE
fix: 修复 cron interval 任务续调与非法更新

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -205,7 +205,7 @@ main() → IrisHost.start()
 ### 架构概览
 
 多 Agent 模式下，Agent 之间可以通过 `delegate_to_agent` 工具进行跨 Agent 委派。
-所有异步任务（sub_agent 异步子代理 + delegate 跨 Agent 委派）统一由 `CrossAgentTaskBoard` 管理。
+所有后台任务（sub_agent 异步子代理 + delegate 跨 Agent 委派 + cron 定时任务）统一由 `CrossAgentTaskBoard` 管理。
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -214,7 +214,7 @@ main() → IrisHost.start()
 │                                                             │
 │  ┌──────────┐  ┌──────────┐  ┌──────────┐                   │
 │  │ TaskRecord│  │ TaskRecord│  │ TaskRecord│  ...             │
-│  │ sub_agent│  │ delegate │  │ sub_agent│                   │
+│  │ sub_agent│  │ delegate │  │   cron   │                   │
 │  └──────────┘  └──────────┘  └──────────┘                   │
 │                                                             │
 │  事件: registered / completed / failed / killed              │
@@ -234,14 +234,14 @@ main() → IrisHost.start()
 
 ### 任务类型与职责分离
 
-| | sub_agent | delegate |
-|---|---|---|
-| 执行位置 | 发起方 Agent 内部 | 目标 Agent 的独立 Backend |
-| 工具集 | 继承父级工具集（可过滤） | 使用目标 Agent 自己的工具集 |
-| 配置 | 继承父级 toolsConfig | 使用目标 Agent 的 tools.yaml |
-| 心跳/token | 有（驱动 StatusBar spinner） | 无（不传递心跳） |
-| 通知合并 | 参与（等全部完成后合并） | 不参与（不阻塞子代理通知） |
-| 前端显示 | 「N 个后台任务 ↑Ntk」（带 spinner） | 「⇢ N 个委派任务」（无 spinner） |
+| | sub_agent | delegate | cron |
+|---|---|---|---|
+| 执行位置 | 发起方 Agent 内部 | 目标 Agent 的独立 Backend | 目标 Agent 的后台 ToolLoop |
+| 工具集 | 继承父级工具集（可过滤） | 使用目标 Agent 自己的工具集 | 使用 cron 后台工具策略 |
+| 配置 | 继承父级 toolsConfig | 使用目标 Agent 的 tools.yaml | 使用 cron.yaml 和任务级配置 |
+| 心跳/token | 有（驱动 StatusBar spinner） | 无（不传递心跳） | 有 |
+| 通知合并 | 参与（等全部完成后合并） | 不参与（不阻塞子代理通知） | 不参与 |
+| 前端显示 | 「N 个后台任务 ↑Ntk」（带 spinner） | 「⇢ N 个委派任务」（无 spinner） | 按 cron 任务通知渲染 |
 
 ### 源码结构
 
@@ -316,8 +316,8 @@ this.emit('agent:notification',
   task.taskId,           // 任务 ID
   status,                // 'registered' | 'completed' | 'failed' | 'killed' | 'token-update' | 'chunk-heartbeat'
   summary,               // 描述文本或 token 数值字符串
-  task.type,             // 'sub_agent' | 'delegate'（第 6 个参数）
+  task.type,             // 'sub_agent' | 'delegate' | 'cron'（第 6 个参数）
 );
 ```
 
-前端据此将两种任务类型分开计数和渲染，互不干扰。
+前端据此将不同任务类型分开计数和渲染，互不干扰。

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -705,7 +705,8 @@ interface IrisAPI {
   listAgents?(): AgentDefinition[];
   agentManager?: AgentManagerLike;     // Agent CRUD 操作
   extensionManager?: ExtensionManagerLike; // 扩展安装/启用/禁用/删除
-  agentTaskRegistry?: unknown;         // 异步子代理任务注册表（供 cron 等后台插件使用）
+  taskBoard?: unknown;                 // 全局任务板（供 cron 等后台插件注册任务）
+  agentName?: string;                  // 当前 Agent 名称
 
   // --- ToolLoop 工厂 ---
   createToolLoop?(options: { tools, systemPrompt, maxRounds? }): ToolLoopRunnerLike; // 创建 ToolLoop 实例供插件后台执行 LLM+工具循环

--- a/extensions/cron/dist/index.mjs
+++ b/extensions/cron/dist/index.mjs
@@ -1,6 +1,6 @@
-// node_modules/irises-extension-sdk/dist/scheduler.js
+// ../../packages/extension-sdk/dist/scheduler.js
 var SCHEDULER_SERVICE_ID = "scheduler.tasks";
-// node_modules/irises-extension-sdk/dist/logger.js
+// ../../packages/extension-sdk/dist/logger.js
 var LogLevel;
 (function(LogLevel2) {
   LogLevel2[LogLevel2["DEBUG"] = 0] = "DEBUG";
@@ -32,7 +32,7 @@ function createExtensionLogger(extensionName, tag) {
   };
 }
 
-// node_modules/irises-extension-sdk/dist/plugin/context.js
+// ../../packages/extension-sdk/dist/plugin/context.js
 function createPluginLogger(pluginName, tag) {
   const scope = tag ? `Plugin:${pluginName}:${tag}` : `Plugin:${pluginName}`;
   return createExtensionLogger(scope);
@@ -41,7 +41,7 @@ function definePlugin(plugin) {
   return plugin;
 }
 
-// node_modules/irises-extension-sdk/dist/plugin/service.js
+// ../../packages/extension-sdk/dist/plugin/service.js
 function waitForServiceAndRegister(services, serviceId, register, timeoutMs = 1e4) {
   let disposed = false;
   let registration;
@@ -57,14 +57,15 @@ function waitForServiceAndRegister(services, serviceId, register, timeoutMs = 1e
     }
   };
 }
-// node_modules/irises-extension-sdk/dist/runtime-paths.js
+// ../../packages/extension-sdk/dist/runtime-paths.js
 import os from "node:os";
 import path from "node:path";
 function resolveDefaultDataDir(customDataDir) {
   return path.resolve(customDataDir || process.env.IRIS_DATA_DIR || path.join(os.homedir(), ".iris"));
 }
-// ../console/src/settings-tab-service.ts
-var CONSOLE_SETTINGS_TAB_SERVICE_ID = "console:settings-tab";
+// ../../packages/extension-sdk/dist/console.js
+var CONSOLE_SETTINGS_TAB_SERVICE_ID2 = "console:settings-tab";
+
 // src/scheduler.ts
 import * as fs from "fs";
 import * as path2 from "path";
@@ -1078,6 +1079,27 @@ function generateId() {
     return v2.toString(16);
   });
 }
+function getNextCronTime(expression, after) {
+  const job = new E(expression);
+  const next = after ? job.nextRun(after) : job.nextRun();
+  if (!next) {
+    throw new Error(`未找到匹配的 cron 触发时间: "${expression}"`);
+  }
+  return next;
+}
+function assertValidSchedule(schedule) {
+  if (schedule.type === "interval" && (!Number.isSafeInteger(schedule.ms) || schedule.ms <= 0)) {
+    throw new Error(`无效 interval 值: ${schedule.ms}`);
+  }
+}
+function resolveNextTaskBoardRunAt(source) {
+  switch (source.kind) {
+    case "interval":
+      return Date.now() + source.intervalMs;
+    case "cron":
+      return getNextCronTime(source.expression).getTime();
+  }
+}
 var cronTaskCounter = 0;
 function createCronTaskId() {
   return `cron_task_${++cronTaskCounter}_${Date.now()}`;
@@ -1156,6 +1178,7 @@ class CronScheduler {
     logger2.info("调度器已停止");
   }
   createJob(params) {
+    assertValidSchedule(params.schedule);
     const job = {
       id: generateId(),
       name: params.name,
@@ -1187,6 +1210,9 @@ class CronScheduler {
     const job = this.jobs.get(id);
     if (!job)
       return null;
+    if (params.schedule !== undefined) {
+      assertValidSchedule(params.schedule);
+    }
     if (params.name !== undefined)
       job.name = params.name;
     if (params.schedule !== undefined)
@@ -1353,12 +1379,7 @@ class CronScheduler {
       return this.executeCronJob(job, taskId2, signal);
     };
     this.executorJobMap.set(executor, job);
-    const nextTimeResolver = job.schedule.type === "cron" ? (source) => {
-      if (source.kind !== "cron")
-        return null;
-      const next = new E(source.expression).nextRun();
-      return next?.getTime() ?? null;
-    } : undefined;
+    const nextTimeResolver = schedule.type === "recurring" ? resolveNextTaskBoardRunAt : undefined;
     const taskId = createCronTaskId();
     const targetSessionId = job.delivery.sessionId ?? job.sessionId;
     this.taskBoard.register({
@@ -1377,6 +1398,7 @@ class CronScheduler {
     this.debouncePersist();
   }
   buildScheduleConfig(job) {
+    assertValidSchedule(job.schedule);
     switch (job.schedule.type) {
       case "cron": {
         const next = new E(job.schedule.expression).nextRun();
@@ -1880,6 +1902,17 @@ function injectScheduler(s2) {
 function clearScheduler() {
   scheduler = null;
 }
+function parseIntervalMs(value) {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return { error: `无效的间隔值: "${value}"，应为正整数毫秒数` };
+  }
+  const ms = Number(trimmed);
+  if (!Number.isSafeInteger(ms) || ms <= 0) {
+    return { error: `无效的间隔值: "${value}"，应为正整数毫秒数` };
+  }
+  return { ms };
+}
 function setCurrentSessionId(sid) {
   currentSessionId = sid;
 }
@@ -1996,11 +2029,11 @@ var manageScheduledTasksTool = {
             schedule = { type: "cron", expression: scheduleValue };
             break;
           case "interval": {
-            const ms = parseInt(scheduleValue, 10);
-            if (isNaN(ms) || ms <= 0) {
-              return { error: `无效的间隔值: "${scheduleValue}"，应为正整数毫秒数` };
+            const result = parseIntervalMs(scheduleValue);
+            if ("error" in result) {
+              return { error: result.error };
             }
-            schedule = { type: "interval", ms };
+            schedule = { type: "interval", ms: result.ms };
             break;
           }
           case "once": {
@@ -2078,9 +2111,14 @@ var manageScheduledTasksTool = {
             case "cron":
               updateParams.schedule = { type: "cron", expression: sv };
               break;
-            case "interval":
-              updateParams.schedule = { type: "interval", ms: parseInt(sv, 10) };
+            case "interval": {
+              const result = parseIntervalMs(sv);
+              if ("error" in result) {
+                return { error: result.error };
+              }
+              updateParams.schedule = { type: "interval", ms: result.ms };
               break;
+            }
             case "once": {
               const result = parseOnceScheduleValue(sv);
               if ("error" in result) {
@@ -2341,7 +2379,7 @@ function createCronSchedulerService(scheduler2, api) {
 // src/index.ts
 var logger4 = createPluginLogger("cron");
 function registerSettingsTabWithConsoleService(api, tab) {
-  return waitForServiceAndRegister(api.services, CONSOLE_SETTINGS_TAB_SERVICE_ID, (service) => service.register(tab), 5000);
+  return waitForServiceAndRegister(api.services, CONSOLE_SETTINGS_TAB_SERVICE_ID2, (service) => service.register(tab), 5000);
 }
 var schedulerInstance = null;
 var schedulerServiceDisposable;

--- a/extensions/cron/src/scheduler.ts
+++ b/extensions/cron/src/scheduler.ts
@@ -22,6 +22,7 @@ import type {
   CronRunRecord,
   CronBackgroundConfig,
   RunStatus,
+  ScheduleConfig,
 } from './types.js';
 import { DEFAULT_SCHEDULER_CONFIG, DEFAULT_BACKGROUND_CONFIG } from './types.js';
 import { shouldSkip } from './delivery-gate.js';
@@ -163,8 +164,25 @@ type TaskBoardExecutor = (taskId: string, signal: AbortSignal) => Promise<string
 
 // [TaskBoard 调度升级对齐] 这里与核心 TaskBoard 的 nextTimeResolver 命名保持一致，
 // 避免 cron 插件注册任务时把续调回调写到错误字段，导致 recurring 任务无法自动续排。
-// 返回值保留 number | null，方便插件侧在“无法计算下一次时间”时显式放弃续调。
-type TaskBoardNextTimeResolver = (source: TaskBoardScheduleSource) => number | null;
+type TaskBoardNextTimeResolver = (source: TaskBoardScheduleSource) => number;
+
+// interval 的合法性必须在 scheduler 核心层兜住：
+// CLI、LLM tool、文件热同步都可能写入任务，后续 TaskBoard 只消费绝对时间戳。
+function assertValidSchedule(schedule: ScheduleConfig): void {
+  if (schedule.type === 'interval' && (!Number.isSafeInteger(schedule.ms) || schedule.ms <= 0)) {
+    throw new Error(`无效 interval 值: ${schedule.ms}`);
+  }
+}
+
+// TaskBoard 只保存 source 元信息；cron 插件负责把不同重复规则还原为下一次触发时间。
+function resolveNextTaskBoardRunAt(source: TaskBoardScheduleSource): number {
+  switch (source.kind) {
+    case 'interval':
+      return Date.now() + source.intervalMs;
+    case 'cron':
+      return getNextCronTime(source.expression).getTime();
+  }
+}
 
 /**
  * CrossAgentTaskBoard 的最小接口（面向插件侧使用）。
@@ -374,6 +392,8 @@ export class CronScheduler {
    * @returns 创建好的任务对象
    */
   createJob(params: CreateJobParams): ScheduledJob {
+    assertValidSchedule(params.schedule);
+
     const job: ScheduledJob = {
       id: generateId(),
       name: params.name,
@@ -416,6 +436,10 @@ export class CronScheduler {
   updateJob(id: string, params: UpdateJobParams): ScheduledJob | null {
     const job = this.jobs.get(id);
     if (!job) return null;
+
+    if (params.schedule !== undefined) {
+      assertValidSchedule(params.schedule);
+    }
 
     // 逐字段合并
     if (params.name !== undefined) job.name = params.name;
@@ -684,13 +708,7 @@ export class CronScheduler {
 
     // [TaskBoard 调度升级对齐] 计算“下一次执行时间”的回调由插件提供给 TaskBoard。
     const nextTimeResolver: TaskBoardNextTimeResolver | undefined =
-      job.schedule.type === 'cron'
-        ? (source) => {
-            if (source.kind !== 'cron') return null;
-            const next = new Cron(source.expression).nextRun();
-            return next?.getTime() ?? null;
-          }
-        : undefined;
+      schedule.type === 'recurring' ? resolveNextTaskBoardRunAt : undefined;
 
     const taskId = createCronTaskId();
     const targetSessionId = job.delivery.sessionId ?? job.sessionId;
@@ -721,6 +739,8 @@ export class CronScheduler {
    * 后续 recurring 的续调再通过 nextRunResolver 完成。
    */
   private buildScheduleConfig(job: ScheduledJob): TaskBoardScheduleConfig | null {
+    assertValidSchedule(job.schedule);
+
     switch (job.schedule.type) {
       case 'cron': {
         const next = new Cron(job.schedule.expression).nextRun();

--- a/extensions/cron/src/tool.ts
+++ b/extensions/cron/src/tool.ts
@@ -114,6 +114,19 @@ export function clearScheduler(): void {
   scheduler = null;
 }
 
+// LLM 工具入口只接受完整的正整数毫秒字符串，避免 parseInt 把 "10abc" 这类输入截断成合法值。
+function parseIntervalMs(value: string): { ms: number } | { error: string } {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return { error: `无效的间隔值: "${value}"，应为正整数毫秒数` };
+  }
+  const ms = Number(trimmed);
+  if (!Number.isSafeInteger(ms) || ms <= 0) {
+    return { error: `无效的间隔值: "${value}"，应为正整数毫秒数` };
+  }
+  return { ms };
+}
+
 /**
  * 设置当前 turn 的 sessionId
  * 由插件入口通过 onBeforeChat 钩子在每次 chat 前调用。
@@ -262,11 +275,11 @@ export const manageScheduledTasksTool: ToolDefinition = {
             schedule = { type: 'cron', expression: scheduleValue };
             break;
           case 'interval': {
-            const ms = parseInt(scheduleValue, 10);
-            if (isNaN(ms) || ms <= 0) {
-              return { error: `无效的间隔值: "${scheduleValue}"，应为正整数毫秒数` };
+            const result = parseIntervalMs(scheduleValue);
+            if ('error' in result) {
+              return { error: result.error };
             }
-            schedule = { type: 'interval', ms };
+            schedule = { type: 'interval', ms: result.ms };
             break;
           }
           case 'once': {
@@ -355,9 +368,14 @@ export const manageScheduledTasksTool: ToolDefinition = {
             case 'cron':
               updateParams.schedule = { type: 'cron', expression: sv };
               break;
-            case 'interval':
-              updateParams.schedule = { type: 'interval', ms: parseInt(sv, 10) };
+            case 'interval': {
+              const result = parseIntervalMs(sv);
+              if ('error' in result) {
+                return { error: result.error };
+              }
+              updateParams.schedule = { type: 'interval', ms: result.ms };
               break;
+            }
             case 'once': {
               // [once 时间解析] update 时也走同一套解析逻辑
               const result = parseOnceScheduleValue(sv);

--- a/src/core/cross-agent-task-board.ts
+++ b/src/core/cross-agent-task-board.ts
@@ -266,6 +266,11 @@ export class CrossAgentTaskBoard extends EventEmitter {
    * 返回创建的 TaskRecord（含 AbortController）。
    */
   register(input: RegisterTaskInput): TaskRecord {
+    // recurring executor 完成后必须能算出下一次时间；注册阶段失败比执行一次后静默断链更安全。
+    if (input.executor && input.schedule?.type === 'recurring' && !input.nextTimeResolver) {
+      throw new Error('Recurring scheduled tasks require nextTimeResolver');
+    }
+
     const task: TaskRecord = {
       ...input,
       status: 'running',

--- a/tests/cron-background-execution.test.ts
+++ b/tests/cron-background-execution.test.ts
@@ -30,6 +30,7 @@ import { DEFAULT_SCHEDULER_CONFIG } from '../extensions/cron/src/types.js';
 // [croner 迁移测试修复] 显式导入 getNextCronTime，
 // 让底部的 croner 集成测试直接验证插件对外暴露的时间计算包装函数。
 import { CronScheduler, getNextCronTime } from '../extensions/cron/src/scheduler.js';
+import { clearScheduler, injectScheduler, manageScheduledTasksTool } from '../extensions/cron/src/tool.js';
 
 // DEFAULT_BACKGROUND_CONFIG 可能因模块别名导致导入为 undefined，
 // 此处手动定义预期的默认值用于断言。
@@ -315,6 +316,34 @@ describe('CronScheduler 后台执行', () => {
     expect(deleted).toBe(false);
   });
 
+  it('interval 任务注册到 TaskBoard 时携带续调 resolver', async () => {
+    await scheduler.start();
+
+    scheduler.createJob({
+      name: 'interval 续调测试',
+      schedule: { type: 'interval', ms: 60_000 },
+      sessionId: 'sess-1',
+      instruction: '操作',
+      createdInSession: 'sess-1',
+    });
+
+    const input = mockTaskBoard.register.mock.calls.at(-1)?.[0] as {
+      schedule?: { type: 'recurring'; source: { kind: 'interval'; intervalMs: number } };
+      nextTimeResolver?: (source: { kind: 'interval'; intervalMs: number }) => number;
+    };
+
+    expect(input.schedule).toMatchObject({
+      type: 'recurring',
+      source: { kind: 'interval', intervalMs: 60_000 },
+    });
+    expect(input.nextTimeResolver).toBeTypeOf('function');
+
+    const before = Date.now();
+    const nextRunAt = input.nextTimeResolver!(input.schedule!.source);
+    expect(nextRunAt).toBeGreaterThanOrEqual(before + 60_000);
+    expect(nextRunAt).toBeLessThanOrEqual(Date.now() + 60_000);
+  });
+
   it('文件同步仅更新运行状态时，不替换任务对象，也不重复注册 TaskBoard 任务', async () => {
     await scheduler.start();
 
@@ -385,6 +414,51 @@ describe('CronScheduler 后台执行', () => {
     expect(currentTaskId).toBeDefined();
     expect(currentTaskId).not.toBe(originalTaskId);
     expect(scheduler.getJob(job.id)?.instruction).toBe('更新后的指令');
+  });
+
+  it('updateJob 拒绝非法 interval 并保留原调度', async () => {
+    await scheduler.start();
+
+    const job = scheduler.createJob({
+      name: '非法 interval 更新测试',
+      schedule: { type: 'interval', ms: 60_000 },
+      sessionId: 'sess-1',
+      instruction: '原始指令',
+      createdInSession: 'sess-1',
+    });
+
+    expect(() => scheduler.updateJob(job.id, {
+      schedule: { type: 'interval', ms: Number.NaN },
+    })).toThrow('无效 interval 值');
+
+    expect(scheduler.getJob(job.id)?.schedule).toEqual({ type: 'interval', ms: 60_000 });
+  });
+
+  it('manage_scheduled_tasks update 拒绝非法 interval 值', async () => {
+    await scheduler.start();
+    injectScheduler(scheduler);
+
+    try {
+      const job = scheduler.createJob({
+        name: '工具非法 interval 更新测试',
+        schedule: { type: 'interval', ms: 60_000 },
+        sessionId: 'sess-1',
+        instruction: '原始指令',
+        createdInSession: 'sess-1',
+      });
+
+      const result = await manageScheduledTasksTool.handler({
+        action: 'update',
+        job_id: job.id,
+        schedule_type: 'interval',
+        schedule_value: 'not-a-number',
+      }) as { error?: string };
+
+      expect(result.error).toContain('无效的间隔值');
+      expect(scheduler.getJob(job.id)?.schedule).toEqual({ type: 'interval', ms: 60_000 });
+    } finally {
+      clearScheduler();
+    }
   });
 
   it('完成后将 lastRunStatus 统一写为 completed，并兼容旧 success 持久化值', async () => {

--- a/tests/cross-agent-task-board.test.ts
+++ b/tests/cross-agent-task-board.test.ts
@@ -1326,6 +1326,28 @@ describe('CrossAgentTaskBoard', () => {
       board.dispose();
     });
 
+    it('recurring executor 缺少 nextTimeResolver 时快速失败', () => {
+      const board = new CrossAgentTaskBoard();
+      const executor: TaskExecutor = async () => 'done';
+
+      expect(() => board.register({
+        taskId: 'sched_missing_resolver',
+        sourceAgent: 'a',
+        sourceSessionId: 's1',
+        targetAgent: 'a',
+        type: 'cron',
+        description: 'bad recurring',
+        schedule: {
+          type: 'recurring',
+          nextRunAt: Date.now(),
+          source: { kind: 'interval', intervalMs: 50 },
+        },
+        executor,
+      })).toThrow('Recurring scheduled tasks require nextTimeResolver');
+
+      board.dispose();
+    });
+
     it('recurring 模式：完成后自动排下一次', async () => {
       const board = new CrossAgentTaskBoard();
       let executionCount = 0;


### PR DESCRIPTION
本 PR 修复 cron interval 类型任务注册到 TaskBoard 后只执行一次的问题。

问题原因是 interval 任务虽然被注册为 recurring 调度，但没有向 TaskBoard 提供 `nextTimeResolver`，导致任务完成后 TaskBoard 无法计算下一次执行时间。cron 表达式任务已有对应 resolver，因此表现正常。

本次更改主要包括：

- 为 cron 与 interval recurring 任务统一提供下一次执行时间解析逻辑。
- 在 TaskBoard 注册 recurring executor 时要求必须提供 `nextTimeResolver`，避免任务执行一次后静默断链。
- 修复 `manage_scheduled_tasks` 更新 interval 时的非法值处理，拒绝非正整数毫秒值，并避免 `parseInt` 截断非法输入。
- 在 CronScheduler 核心层补充 interval 合法性校验，覆盖工具调用、CLI/文件同步等不同入口。
- 补充相关单元测试，并同步更新 TaskBoard/cron 相关文档说明。